### PR TITLE
Load config from %LOCALAPPDATA%\redshift.conf on Windows

### DIFF
--- a/src/config-ini.c
+++ b/src/config-ini.c
@@ -50,9 +50,9 @@ open_config_file(const char *filepath)
 			snprintf(cp, sizeof(cp), "%s/redshift.conf", env);
 			filepath = cp;
 #ifdef _WIN32
-		} else if ((env = getenv("userprofile")) != NULL && env[0] != '\0') {
+		} else if ((env = getenv("localappdata")) != NULL && env[0] != '\0') {
 			snprintf(cp, sizeof(cp),
-				 "%s/.config/redshift.conf", env);
+				 "%s\\redshift.conf", env);
 			filepath = cp;
 #endif
 		} else if ((env = getenv("HOME")) != NULL && env[0] != '\0') {


### PR DESCRIPTION
Using ~/.config on Windows is out of place.
