### PR TITLE
Fix building on Windows

### DIFF
--- a/src/gamma-dummy.c
+++ b/src/gamma-dummy.c
@@ -27,8 +27,6 @@
 # define _(s) s
 #endif
 
-#include "gamma-randr.h"
-
 
 int
 gamma_dummy_init(void *state)


### PR DESCRIPTION
I am not sure why this file was included, nothing from it seems to be used. `<xcb/xcb.h>` certainly is not always available though.
