### PR TITLE
Add systemd .service file for redshift

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -25,6 +25,8 @@ _UBUNTU_MONO_LIGHT_FILES = \
 _DESKTOP_FILES = \
 	data/applications/redshift-gtk.desktop
 
+_SYSTEMD_USER_UNIT_FILES = \
+	data/systemd/redshift.service.in
 
 # Icons
 if ENABLE_GUI
@@ -40,6 +42,10 @@ ubuntu_mono_light_icon_DATA = $(_UBUNTU_MONO_LIGHT_FILES)
 endif
 endif
 
+# Systemd service files
+if ENABLE_SYSTEMD
+systemduserunit_DATA = data/systemd/redshift.service
+endif
 
 # Desktop file
 if ENABLE_GUI
@@ -63,7 +69,13 @@ EXTRA_DIST = \
 	$(_HICOLOR_FILES) \
 	$(_UBUNTU_MONO_DARK_FILES) \
 	$(_UBUNTU_MONO_LIGHT_FILES) \
-	$(_DESKTOP_FILES)
+	$(_DESKTOP_FILES) \
+	$(_SYSTEMD_USER_UNIT_FILES)
+
+CLEANFILES = data/systemd/redshift.service
+
+data/systemd/redshift.service: data/systemd/redshift.service.in
+	$(AM_V_GEN)sed -e "s|\@bindir\@|$(bindir)|g" $< > $@
 
 # Update PO translations
 .PHONY: update-po

--- a/configure.ac
+++ b/configure.ac
@@ -161,6 +161,26 @@ AS_IF([test "x$enable_ubuntu" != xno], [
 ])
 AM_CONDITIONAL([ENABLE_UBUNTU], [test "x$enable_ubuntu" != xno])
 
+# Check for systemd
+PKG_PROG_PKG_CONFIG
+AC_MSG_CHECKING([Directory to install systemd user unit files])
+AC_ARG_WITH([systemduserunitdir],
+            [AC_HELP_STRING([--with-systemduserunitdir],
+                            [Directory for systemd user unit files])],
+            [], [with_systemduserunitdir=no])
+# If no path is given, use pkg-config
+AS_IF([test "x$with_systemduserunitdir" == xyes],
+      [AC_SUBST([systemduserunitdir],
+                [$($PKG_CONFIG --variable=systemduserunitdir systemd)])],
+      [AC_SUBST([systemduserunitdir],
+                [$with_systemduserunitdir])]
+     )
+AC_MSG_RESULT([$systemduserunitdir])
+AS_IF([test -n "$with_systemduserunitdir" -a "x$with_systemduserunitdir" != xno],
+      [enable_systemd=yes],
+      [enable_systemd=no])
+AM_CONDITIONAL([ENABLE_SYSTEMD], [test "x$enable_systemd" != xno])
+
 # Checks for header files.
 AC_CHECK_HEADERS([locale.h stdint.h stdlib.h string.h unistd.h signal.h])
 
@@ -200,4 +220,5 @@ echo "
 
     GUI:		${enable_gui}
     Ubuntu icons:	${enable_ubuntu}
+    systemd unit path:	${systemduserunitdir}
 "

--- a/data/systemd/redshift.service.in
+++ b/data/systemd/redshift.service.in
@@ -1,0 +1,11 @@
+[Unit]
+Description=Redshift display colour temperature adjustment
+Documentation=http://jonls.dk/redshift/
+After=display-manager.service
+
+[Service]
+ExecStart=@bindir@/redshift
+Restart=always
+
+[Install]
+WantedBy=default.target


### PR DESCRIPTION
Adds a new configure option, `--enable-systemd`, defaulting to "check",
which optionally installs a systemd user service file to allow users to
run redshift as a daemon using systemd.
