### PR TITLE
Free resources from config-ini.c on exit

### DIFF
--- a/src/config-ini.c
+++ b/src/config-ini.c
@@ -216,15 +216,19 @@ config_ini_free(config_ini_state_t *state)
 
 	while (section != NULL) {
 		config_ini_setting_t *setting = section->settings;
+		config_ini_section_t *section_prev = section;
 
 		while (setting != NULL) {
+			config_ini_setting_t *setting_prev = setting;
 			free(setting->name);
 			free(setting->value);
 			setting = setting->next;
+			free(setting_prev);
 		}
 
 		free(section->name);
 		section = section->next;
+		free(section_prev);
 	}
 }
 

--- a/src/redshift.c
+++ b/src/redshift.c
@@ -1089,6 +1089,8 @@ main(int argc, char *argv[])
 		}
 	}
 
+	config_ini_free(&config_state);
+
 	switch (mode) {
 	case PROGRAM_MODE_ONE_SHOT:
 	case PROGRAM_MODE_PRINT:


### PR DESCRIPTION
Free resources from config-ini.c on exit, so that valgrind cannot find any leaks (unless geoclue is enabled.)
