### PR TITLE
Fix todo in redshift-gtk: toggle_item is checkbox that follows the icon

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+# Backup files
+*~
+\#*\#
+
 # Object files
 *.o
 *.ko
@@ -40,6 +44,7 @@ src/redshift-gtk/defs.py
 src/redshift-gtk/redshift-gtk
 contrib/redshift.spec
 src/redshift
+src/redshift-gtk/__pycache__/
 
 # gettext
 /po/POTFILES


### PR DESCRIPTION
I have made `toggle_item` into a `CheckMenuItem` with the label "Enabled".
Whenever the status is updated `toggle_item`'s active state is set accordingly.
This lead to an loop where setting the active status of `toggle_item` triggered
the active event that calls `toggle_cb` which changes the status.
I resolved adding a semaphore (which a thread cannot enter multiple times
concurrently) that is acquired when change the active status if `toggle_item`,
but also — non-blockingly — around the instructions in `toggle_cb`.
