### PR TITLE
Apply gamma after brightness and temperature

### DIFF
--- a/src/colorramp.c
+++ b/src/colorramp.c
@@ -291,12 +291,11 @@ colorramp_fill(uint16_t *gamma_r, uint16_t *gamma_g, uint16_t *gamma_b,
 	interpolate_color(alpha, &blackbody_color[temp_index],
 			  &blackbody_color[temp_index+3], white_point);
 
+#define F(Y, C)  pow((Y) * brightness * white_point[C], 1.0/gamma[C])
+
 	for (int i = 0; i < size; i++) {
-		gamma_r[i] = pow((float)i/size, 1.0/gamma[0]) *
-			(UINT16_MAX+1) * brightness * white_point[0];
-		gamma_g[i] = pow((float)i/size, 1.0/gamma[1]) *
-			(UINT16_MAX+1) * brightness * white_point[1];
-		gamma_b[i] = pow((float)i/size, 1.0/gamma[2]) *
-			(UINT16_MAX+1) * brightness * white_point[2];
+		gamma_r[i] = F((float)i/size, 0) * (UINT16_MAX+1);
+		gamma_g[i] = F((float)i/size, 1) * (UINT16_MAX+1);
+		gamma_b[i] = F((float)i/size, 2) * (UINT16_MAX+1);
 	}
 }


### PR DESCRIPTION
This applies the gamma correction after brightness and temperature
rather than before brightness and temperature.

Since gamma is a correction of the output of the monitor it should
be applied last so that all colour filters are also subject to this correction.
The effect of this change increases the brightness or temperature
gets lower. With my gamma settings (above 1) 3000 K is not as red
with the patch as without, and is closer to that in https://upload.wikimedia.org/wikipedia/commons/d/d7/Planckian-locus.png
than without this patch.

Edit: Nevermind that picture, it is very inaccurate.
