### PR TITLE
GeoClue when not in X

### DIFF
--- a/src/location-geoclue.c
+++ b/src/location-geoclue.c
@@ -60,6 +60,10 @@ location_geoclue_start(location_geoclue_state_t *state)
 		state->position = geoclue_position_new(state->provider,
 						       state->provider_path);
         } else {
+		if (getenv("DISPLAY") == NULL || *getenv("DISPLAY") == '\0') {
+			/* TODO This (hack) should be removed when GeoClue has been patched. */
+			putenv("DISPLAY=:0");
+		}
                 GError *error = NULL;
                 GeoclueMaster *master = geoclue_master_get_default();
                 GeoclueMasterClient *client = geoclue_master_create_client(master,


### PR DESCRIPTION
This patch makes sure redshift does not segfault
when it fails to start GeoClue without running in X
by not assuming that an error message was provided.

Additionally it does a hack were it sets DISPLAY=:0
if DISPLAY is missing, in an attempt to give GeoClue
an X display. This would only work if X is actually
running on :0, and perhaps only (I do not know) if
the user owns that display.
