### PR TITLE
Do not apply gamma changes while disabled and not in a transition

### DIFF
--- a/src/redshift.c
+++ b/src/redshift.c
@@ -1351,7 +1351,7 @@ main(int argc, char *argv[])
 			}
 
 			/* Adjust temperature */
-			if (!disabled || short_trans) {
+			if (!disabled || (short_trans && !short_trans_done)) {
 				r = method->set_temperature(&state,
 							    temp, brightness,
 							    gamma);


### PR DESCRIPTION
Appearently I had already resolved this (unintentionally) in #41,
but I just wrote this small change and figured why not. It is very
small change that makes so that redshift does not update the
gamma ramps while it is disabled and not in a transition. This
allows you to disable redshift without exiting it and apply changes
with another program or another instance of redshift without
having the disabled instance of redshift remove the changes.
