### PR TITLE
Relay SIGUSR1 to redshift from redshift-gtk

### DIFF
--- a/src/redshift-gtk/statusicon.py
+++ b/src/redshift-gtk/statusicon.py
@@ -40,10 +40,10 @@ from . import utils
 _ = gettext.gettext
 
 
-def sigterm_handler(signal, frame):
+def exit_signal_handler(signal, frame):
     sys.exit()
 
-def sigx_handler(signal, frame):
+def relay_signal_handler(signal, frame):
     os.kill(redshift_proc, signal)
 
 
@@ -57,7 +57,8 @@ class RedshiftStatusIcon(object):
         self._location = (0.0, 0.0)
 
         # Install TERM signal handler
-        signal.signal(signal.SIGTERM, sigterm_handler)
+        signal.signal(signal.SIGTERM, exit_signal_handler)
+        signal.signal(signal.SIGINT,  exit_signal_handler)
 
         # Start redshift with arguments
         args.insert(0, os.path.join(defs.BINDIR, 'redshift'))
@@ -68,7 +69,7 @@ class RedshiftStatusIcon(object):
         redshift_proc = self.process[0]
 
         # Install relay signal handlers
-        signal.signal(signal.SIGUSR1, sigx_handler)
+        signal.signal(signal.SIGUSR1, relay_signal_handler)
 
         if appindicator:
             # Create indicator


### PR DESCRIPTION
Current, if redshift-gtk receives SIGUSR1, redshift-gtk will terminate.
With this patch if redshift-gtk receives SIGUSR1 it will send it to redshift.

This patch should close:
https://bugs.launchpad.net/redshift/+bug/663637 (well I do not know what
a systemshortcut is but it sounds like something that should be done with
xbindkeys.)
