### PR TITLE
Fix building systemd unit files

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -75,7 +75,7 @@ endif
 
 $(systemduserunit_DATA): $(SYSTEMD_USER_UNIT_IN_FILES) Makefile
 	$(AM_V_GEN)$(MKDIR_P) $(@D) && \
-		sed -e "s|\@bindir\@|$(bindir)|g" $< > $@
+		sed -e "s|\@bindir\@|$(bindir)|g" "$(srcdir)/$(@:.service=.service.in)" > $@
 
 
 


### PR DESCRIPTION
The previous Makefile rule would generate all unit files from
`redshift.service.in`. This is fixed to generate the file from the proper
`.service.in` file.
