### PR TITLE
Reloading of settings

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -10,6 +10,7 @@ bin_PROGRAMS = redshift
 
 redshift_SOURCES = \
 	redshift.c redshift.h \
+	settings.c settings.h \
 	colorramp.c colorramp.h \
 	config-ini.c config-ini.h \
 	location-manual.c location-manual.h \

--- a/src/redshift-gtk/statusicon.py
+++ b/src/redshift-gtk/statusicon.py
@@ -94,6 +94,11 @@ class RedshiftStatusIcon(object):
         suspend_menu_item.set_submenu(suspend_menu)
         self.status_menu.append(suspend_menu_item)
 
+        # Add reload action
+        self.reload_item = Gtk.MenuItem.new_with_label(_('Reload settings'))
+        self.reload_item.connect('activate', self.reload_item_cb)
+        self.status_menu.append(self.reload_item)
+
         # Add autostart option
         autostart_item = Gtk.CheckMenuItem.new_with_label(_('Autostart'))
         try:
@@ -227,6 +232,10 @@ class RedshiftStatusIcon(object):
             self.remove_suspend_timer()
             self.child_toggle_status()
 
+    def reload_item_cb(self, widget, data=None):
+        # Only toggle if a change from current state was requested
+        self.child_reload_settings()
+
     # Info dialog callbacks
     def show_info_cb(self, widget, data=None):
         self.info_dialog.show()
@@ -284,6 +293,9 @@ class RedshiftStatusIcon(object):
 
     def child_toggle_status(self):
         os.kill(self.process[0], signal.SIGUSR1)
+
+    def child_reload_settings(self):
+        os.kill(self.process[0], signal.SIGUSR2)
 
     def child_cb(self, pid, cond, data=None):
         sys.exit(-1)

--- a/src/redshift.c
+++ b/src/redshift.c
@@ -1150,7 +1150,19 @@ main(int argc, char *argv[])
 					settings_copy(&settings, &new_settings);
 				}
 				
-				/* FIXME */
+				if (verbose) {
+				        /* TRANSLATORS: Append degree symbols if possible. */
+				        printf(_("Location: %f, %f\n"), lat, lon);
+					printf(_("Temperatures: %dK at day, %dK at night\n"),
+					       settings.temp_day, settings.temp_night);
+				        /* TRANSLATORS: Append degree symbols if possible. */
+					printf(_("Solar elevations: day above %.1f, night below %.1f\n"),
+					       settings.transition_high, settings.transition_low);
+					printf(_("Brightness: %.2f:%.2f\n"),
+					       settings.brightness_day, settings.brightness_night);
+					printf(_("Gamma: %.3f, %.3f, %.3f\n"),
+					       settings.gamma[0], settings.gamma[1], settings.gamma[2]);
+				}
 			}
 		reload_failed:
 

--- a/src/redshift.c
+++ b/src/redshift.c
@@ -204,12 +204,6 @@ static const location_provider_t location_providers[] = {
 #define MAX_LAT    90.0
 #define MIN_LON  -180.0
 #define MAX_LON   180.0
-#define MIN_TEMP   1000
-#define MAX_TEMP  25000
-#define MIN_BRIGHTNESS  0.1
-#define MAX_BRIGHTNESS  1.0
-#define MIN_GAMMA   0.1
-#define MAX_GAMMA  10.0
 
 /* The color temperature when no adjustment is applied. */
 #define NEUTRAL_TEMP  6500
@@ -932,68 +926,15 @@ main(int argc, char *argv[])
 		                  " %.1f and %.1f.\n"), MIN_LON, MAX_LON);
 		        exit(EXIT_FAILURE);
 		}
-
-		/* Color temperature at daytime */
-		if (settings.temp_day < MIN_TEMP || settings.temp_day > MAX_TEMP) {
-			fprintf(stderr,
-				_("Temperature must be between %uK and %uK.\n"),
-				MIN_TEMP, MAX_TEMP);
-			exit(EXIT_FAILURE);
-		}
-	
-		/* Color temperature at night */
-		if (settings.temp_night < MIN_TEMP || settings.temp_night > MAX_TEMP) {
-			fprintf(stderr,
-				_("Temperature must be between %uK and %uK.\n"),
-				MIN_TEMP, MAX_TEMP);
-			exit(EXIT_FAILURE);
-		}
-
-		/* Solar elevations */
-		if (settings.transition_high < settings.transition_low) {
-		        fprintf(stderr,
-		                _("High transition elevation cannot be lower than"
-				  " the low transition elevation.\n"));
-		        exit(EXIT_FAILURE);
-		}
 	}
-
-	if (mode == PROGRAM_MODE_MANUAL) {
-		/* Check color temperature to be set */
-		if (settings.temp_set < MIN_TEMP || settings.temp_set > MAX_TEMP) {
-			fprintf(stderr,
-				_("Temperature must be between %uK and %uK.\n"),
-				MIN_TEMP, MAX_TEMP);
-			exit(EXIT_FAILURE);
-		}
-	}
-
-	/* Brightness */
-	if (settings.brightness_day < MIN_BRIGHTNESS ||
-	    settings.brightness_day > MAX_BRIGHTNESS ||
-	    settings.brightness_night < MIN_BRIGHTNESS ||
-	    settings.brightness_night > MAX_BRIGHTNESS) {
-		fprintf(stderr,
-			_("Brightness values must be between %.1f and %.1f.\n"),
-			MIN_BRIGHTNESS, MAX_BRIGHTNESS);
+	    
+	r = settings_validate(&settings, mode == PROGRAM_MODE_MANUAL, mode == PROGRAM_MODE_RESET);
+	if (r < 0)
 		exit(EXIT_FAILURE);
-	}
 
 	if (verbose) {
-		printf(_("Brightness: %.2f:%.2f\n"), settings.brightness_day, settings.brightness_night);
-	}
-
-	/* Gamma */
-	if (settings.gamma[0] < MIN_GAMMA || settings.gamma[0] > MAX_GAMMA ||
-	    settings.gamma[1] < MIN_GAMMA || settings.gamma[1] > MAX_GAMMA ||
-	    settings.gamma[2] < MIN_GAMMA || settings.gamma[2] > MAX_GAMMA) {
-		fprintf(stderr,
-			_("Gamma value must be between %.1f and %.1f.\n"),
-			MIN_GAMMA, MAX_GAMMA);
-		exit(EXIT_FAILURE);
-	}
-
-	if (verbose) {
+		printf(_("Brightness: %.2f:%.2f\n"),
+		       settings.brightness_day, settings.brightness_night);
 		printf(_("Gamma: %.3f, %.3f, %.3f\n"),
 		       settings.gamma[0], settings.gamma[1], settings.gamma[2]);
 	}

--- a/src/redshift.c
+++ b/src/redshift.c
@@ -1146,9 +1146,8 @@ main(int argc, char *argv[])
 					settings_copy(&old_settings, &settings);
 					reloading = 1;
 					reload_trans = 0;
-				} else {
-					settings_copy(&settings, &new_settings);
 				}
+				settings_copy(&settings, &new_settings);
 				
 				if (verbose) {
 				        /* TRANSLATORS: Append degree symbols if possible. */

--- a/src/redshift.c
+++ b/src/redshift.c
@@ -222,6 +222,7 @@ typedef enum {
 
 static volatile sig_atomic_t exiting = 0;
 static volatile sig_atomic_t disable = 0;
+static volatile sig_atomic_t reload = 0;
 
 /* Signal handler for exit signals */
 static void
@@ -237,10 +238,18 @@ sigdisable(int signo)
 	disable = 1;
 }
 
+/* Signal handler for reload signal */
+static void
+sigreload(int signo)
+{
+	reload = 1;
+}
+
 #else /* ! HAVE_SIGNAL_H || __WIN32__ */
 
 static int exiting = 0;
 static int disable = 0;
+static int reload = 0;
 
 #endif /* ! HAVE_SIGNAL_H || __WIN32__ */
 
@@ -1077,6 +1086,12 @@ main(int argc, char *argv[])
 		sigact.sa_mask = sigset;
 		sigact.sa_flags = 0;
 		sigaction(SIGUSR1, &sigact, NULL);
+
+		/* Install signal handler for USR2 singal */
+		sigact.sa_handler = sigreload;
+		sigact.sa_mask = sigset;
+		sigact.sa_flags = 0;
+		sigaction(SIGUSR2, &sigact, NULL);
 #endif /* HAVE_SIGNAL_H && ! __WIN32__ */
 
 		if (verbose) {

--- a/src/settings.c
+++ b/src/settings.c
@@ -1,0 +1,41 @@
+/* settings.c -- Main program settings source
+   This file is part of Redshift.
+
+   Redshift is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   Redshift is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with Redshift.  If not, see <http://www.gnu.org/licenses/>.
+
+   Copyright (c) 2013  Jon Lund Steffensen <jonlst@gmail.com>
+   Copyright (c) 2014  Mattias Andrée <maandree@member.fsf.org>
+*/
+
+#include "settings.h"
+
+#include <math.h>
+
+
+void
+settings_init(settings_t *settings)
+{
+  settings->temp_set = -1;
+  settings->temp_day = -1;
+  settings->temp_night = -1;
+  settings->gamma[0] = NAN;
+  settings->gamma[1] = NAN;
+  settings->gamma[2] = NAN;
+  settings->brightness_day = NAN;
+  settings->brightness_night = NAN;
+  settings->transition = -1;
+  settings->transition_low = TRANSITION_LOW;
+  settings->transition_high = TRANSITION_HIGH;
+}
+

--- a/src/settings.c
+++ b/src/settings.c
@@ -18,9 +18,50 @@
    Copyright (c) 2014  Mattias Andrée <maandree@member.fsf.org>
 */
 
+#ifdef HAVE_CONFIG_H
+# include "config.h"
+#endif
+
 #include "settings.h"
 
+#ifdef ENABLE_NLS
+# include <libintl.h>
+# define _(s) gettext(s)
+#else
+# define _(s) s
+#endif
+
 #include <math.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+
+/* A gamma string contains either one floating point value,
+   or three values separated by colon. */
+int
+parse_gamma_string(const char *str, float gamma[])
+{
+	char *s = strchr(str, ':');
+	if (s == NULL) {
+		/* Use value for all channels */
+		float g = atof(str);
+		gamma[0] = gamma[1] = gamma[2] = g;
+	} else {
+		/* Parse separate value for each channel */
+		*(s++) = '\0';
+		char *g_s = s;
+		s = strchr(s, ':');
+		if (s == NULL) return -1;
+
+		*(s++) = '\0';
+		gamma[0] = atof(str); /* Red */
+		gamma[1] = atof(g_s); /* Blue */
+		gamma[2] = atof(s); /* Green */
+	}
+
+	return 0;
+}
 
 
 void
@@ -39,3 +80,51 @@ settings_init(settings_t *settings)
   settings->transition_high = TRANSITION_HIGH;
 }
 
+
+void
+settings_finalize(settings_t *settings)
+{
+  if (settings->temp_day < 0)            settings->temp_day         = DEFAULT_DAY_TEMP;
+  if (settings->temp_night < 0)          settings->temp_night       = DEFAULT_NIGHT_TEMP;
+  if (isnan(settings->brightness_day))   settings->brightness_day   = DEFAULT_BRIGHTNESS;
+  if (isnan(settings->brightness_night)) settings->brightness_night = DEFAULT_BRIGHTNESS;
+  if (isnan(settings->gamma[0]))         settings->gamma[0]         = DEFAULT_GAMMA;
+  if (isnan(settings->gamma[1]))         settings->gamma[1]         = DEFAULT_GAMMA;
+  if (isnan(settings->gamma[2]))         settings->gamma[2]         = DEFAULT_GAMMA;
+  if (settings->transition < 0)          settings->transition       = 1;
+}
+
+
+int
+settings_parse(settings_t *settings, const char* name, char* value)
+{
+	if (strcasecmp(name, "temp-day") == 0) {
+		if (settings->temp_day < 0) settings->temp_day = atoi(value);
+	} else if (strcasecmp(name, "temp-night") == 0) {
+		if (settings->temp_night < 0) settings->temp_night = atoi(value);
+	} else if (strcasecmp(name, "transition") == 0) {
+		if (settings->transition < 0) settings->transition = !!atoi(value);
+	} else if (strcasecmp(name, "brightness") == 0) {
+		if (isnan(settings->brightness_day)) settings->brightness_day = atof(value);
+		if (isnan(settings->brightness_night)) settings->brightness_night = atof(value);
+	} else if (strcasecmp(name, "brightness-day") == 0) {
+		if (isnan(settings->brightness_day)) settings->brightness_day = atof(value);
+	} else if (strcasecmp(name, "brightness-night") == 0) {
+		if (isnan(settings->brightness_night)) settings->brightness_night = atof(value);
+	} else if (strcasecmp(name, "elevation-high") == 0) {
+		settings->transition_high = atof(value);
+	} else if (strcasecmp(name, "elevation-low") == 0) {
+		settings->transition_low = atof(value);
+	} else if (strcasecmp(name, "gamma") == 0) {
+		if (isnan(settings->gamma[0])) {
+			int r = parse_gamma_string(value, settings->gamma);
+			if (r < 0) {
+				fputs(_("Malformed gamma setting.\n"), stderr);
+				return -1;
+			}
+		}
+	} else {
+		return 1;
+	}
+	return 0;
+}

--- a/src/settings.c
+++ b/src/settings.c
@@ -82,6 +82,13 @@ settings_init(settings_t *settings)
 
 
 void
+settings_copy(settings_t *restrict dest, const settings_t *restrict src)
+{
+  memcpy(dest, src, sizeof(settings_t));
+}
+
+
+void
 settings_finalize(settings_t *settings)
 {
   if (settings->temp_day < 0)            settings->temp_day         = DEFAULT_DAY_TEMP;
@@ -151,7 +158,7 @@ settings_validate(settings_t *settings, int manual_mode, int reset_mode)
 				MIN_TEMP, MAX_TEMP);
 		        rc = -1;
 		}
-	
+
 		/* Color temperature at night */
 		if (settings->temp_night < MIN_TEMP || settings->temp_night > MAX_TEMP) {
 			fprintf(stderr,

--- a/src/settings.c
+++ b/src/settings.c
@@ -128,3 +128,67 @@ settings_parse(settings_t *settings, const char* name, char* value)
 	}
 	return 0;
 }
+
+
+int
+settings_validate(settings_t *settings, int manual_mode, int reset_mode)
+{
+	int rc = 0;
+
+	if (manual_mode) {
+		/* Check color temperature to be set */
+		if (settings->temp_set < MIN_TEMP || settings->temp_set > MAX_TEMP) {
+			fprintf(stderr,
+				_("Temperature must be between %uK and %uK.\n"),
+				MIN_TEMP, MAX_TEMP);
+			rc = -1;
+		}
+	} else if (reset_mode == 0) {
+		/* Color temperature at daytime */
+		if (settings->temp_day < MIN_TEMP || settings->temp_day > MAX_TEMP) {
+			fprintf(stderr,
+				_("Temperature must be between %uK and %uK.\n"),
+				MIN_TEMP, MAX_TEMP);
+		        rc = -1;
+		}
+	
+		/* Color temperature at night */
+		if (settings->temp_night < MIN_TEMP || settings->temp_night > MAX_TEMP) {
+			fprintf(stderr,
+				_("Temperature must be between %uK and %uK.\n"),
+				MIN_TEMP, MAX_TEMP);
+		        rc = -1;
+		}
+
+		/* Solar elevations */
+		if (settings->transition_high < settings->transition_low) {
+		        fprintf(stderr,
+		                _("High transition elevation cannot be lower than"
+				  " the low transition elevation.\n"));
+		        rc = -1;
+		}
+	}
+
+	/* Brightness */
+	if (settings->brightness_day < MIN_BRIGHTNESS ||
+	    settings->brightness_day > MAX_BRIGHTNESS ||
+	    settings->brightness_night < MIN_BRIGHTNESS ||
+	    settings->brightness_night > MAX_BRIGHTNESS) {
+		fprintf(stderr,
+			_("Brightness values must be between %.1f and %.1f.\n"),
+			MIN_BRIGHTNESS, MAX_BRIGHTNESS);
+		rc = -1;
+	}
+
+	/* Gamma */
+	if (settings->gamma[0] < MIN_GAMMA || settings->gamma[0] > MAX_GAMMA ||
+	    settings->gamma[1] < MIN_GAMMA || settings->gamma[1] > MAX_GAMMA ||
+	    settings->gamma[2] < MIN_GAMMA || settings->gamma[2] > MAX_GAMMA) {
+		fprintf(stderr,
+			_("Gamma value must be between %.1f and %.1f.\n"),
+			MIN_GAMMA, MAX_GAMMA);
+		rc = -1;
+	}
+
+	return rc;
+}

--- a/src/settings.h
+++ b/src/settings.h
@@ -66,6 +66,7 @@ typedef struct
 int parse_gamma_string(const char *str, float gamma[]);
 
 void settings_init(settings_t *settings);
+void settings_copy(settings_t *restrict dest, const settings_t *restrict src);
 void settings_finalize(settings_t *settings);
 int settings_parse(settings_t *settings, const char* name, char* value);
 int settings_validate(settings_t *settings, int manual_mode, int reset_mode);

--- a/src/settings.h
+++ b/src/settings.h
@@ -1,0 +1,53 @@
+/* settings.h -- Main program settings header
+   This file is part of Redshift.
+
+   Redshift is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   Redshift is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with Redshift.  If not, see <http://www.gnu.org/licenses/>.
+
+   Copyright (c) 2013  Jon Lund Steffensen <jonlst@gmail.com>
+   Copyright (c) 2014  Mattias Andrée <maandree@member.fsf.org>
+*/
+
+#ifndef REDSHIFT_SETTINGS_H
+#define REDSHIFT_SETTINGS_H
+
+#include "solar.h"
+
+
+/* Angular elevation of the sun at which the color temperature
+   transition period starts and ends (in degress).
+   Transition during twilight, and while the sun is lower than
+   3.0 degrees above the horizon. */
+#define TRANSITION_LOW     SOLAR_CIVIL_TWILIGHT_ELEV
+#define TRANSITION_HIGH    3.0
+
+
+typedef struct
+{
+  int temp_set;
+  int temp_day;
+  int temp_night;
+  float gamma[3];
+  float brightness_day;
+  float brightness_night;
+  int transition;
+  float transition_low;
+  float transition_high;
+  
+} settings_t;
+
+
+void settings_init(settings_t *settings);
+
+
+#endif /* ! REDSHIFT_SETTINGS_H */

--- a/src/settings.h
+++ b/src/settings.h
@@ -31,6 +31,12 @@
 #define TRANSITION_LOW     SOLAR_CIVIL_TWILIGHT_ELEV
 #define TRANSITION_HIGH    3.0
 
+/* Default values for parameters. */
+#define DEFAULT_DAY_TEMP    5500
+#define DEFAULT_NIGHT_TEMP  3500
+#define DEFAULT_BRIGHTNESS   1.0
+#define DEFAULT_GAMMA        1.0
+
 
 typedef struct
 {
@@ -47,7 +53,13 @@ typedef struct
 } settings_t;
 
 
+/* A gamma string contains either one floating point value,
+   or three values separated by colon. */
+int parse_gamma_string(const char *str, float gamma[]);
+
 void settings_init(settings_t *settings);
+void settings_finalize(settings_t *settings);
+int settings_parse(settings_t *settings, const char* name, char* value);
 
 
 #endif /* ! REDSHIFT_SETTINGS_H */

--- a/src/settings.h
+++ b/src/settings.h
@@ -57,6 +57,7 @@ typedef struct
   int transition;
   float transition_low;
   float transition_high;
+  int reload_transition;
   
 } settings_t;
 
@@ -70,6 +71,7 @@ void settings_copy(settings_t *restrict dest, const settings_t *restrict src);
 void settings_finalize(settings_t *settings);
 int settings_parse(settings_t *settings, const char* name, char* value);
 int settings_validate(settings_t *settings, int manual_mode, int reset_mode);
+void settings_interpolate(settings_t *out, settings_t low, settings_t high, double weight);
 
 
 #endif /* ! REDSHIFT_SETTINGS_H */

--- a/src/settings.h
+++ b/src/settings.h
@@ -24,6 +24,14 @@
 #include "solar.h"
 
 
+/* Bounds for parameters. */
+#define MIN_TEMP   1000
+#define MAX_TEMP  25000
+#define MIN_BRIGHTNESS  0.1
+#define MAX_BRIGHTNESS  1.0
+#define MIN_GAMMA   0.1
+#define MAX_GAMMA  10.0
+
 /* Angular elevation of the sun at which the color temperature
    transition period starts and ends (in degress).
    Transition during twilight, and while the sun is lower than
@@ -60,6 +68,7 @@ int parse_gamma_string(const char *str, float gamma[]);
 void settings_init(settings_t *settings);
 void settings_finalize(settings_t *settings);
 int settings_parse(settings_t *settings, const char* name, char* value);
+int settings_validate(settings_t *settings, int manual_mode, int reset_mode);
 
 
 #endif /* ! REDSHIFT_SETTINGS_H */


### PR DESCRIPTION
The patch enables to user to send SIGUSR2
or use redshift-gtk to load new settings from
redshift.conf. It is configurable whether the
new settings should kick in directly or if there
should be a short transition to them.

Currently only adjustment settings are reloaded,
but this could be extended to include location,
monitors and adjustment method.
