### PR TITLE
Add hooks for user actions on "mode" switch

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -15,6 +15,7 @@ redshift_SOURCES = \
 	location-manual.c location-manual.h \
 	solar.c solar.h \
 	systemtime.c systemtime.h \
+	hooks.c hooks.h \
 	gamma-dummy.c gamma-dummy.h
 
 EXTRA_redshift_SOURCES = \

--- a/src/hooks.c
+++ b/src/hooks.c
@@ -1,0 +1,124 @@
+/* redshift.h -- Main program header
+   This file is part of Redshift.
+
+   Redshift is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   Redshift is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with Redshift.  If not, see <http://www.gnu.org/licenses/>.
+
+   Copyright (c) 2014  Mattias Andrée <maandree@member.fsf.org>
+*/
+
+#include "hooks.h"
+
+#include <stddef.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/types.h>
+#include <unistd.h>
+#include <stdio.h>
+extern char **environ;
+
+
+
+static char **hooks[3] = { NULL, NULL, NULL };
+static size_t hooks_n[3] = { 0, 0, 0 };
+
+
+
+#ifndef _WIN32
+
+
+void
+run_hooks(int event, int silence)
+{
+	char *command[] = { "sh", "-c", "", NULL };
+	pid_t pid = silence ? fork() : vfork();
+	if (pid == (pid_t)-1)
+		perror(silence ? "fork" : "vfork");
+	if (pid) return;
+
+	/* Make sure out does not interfere with front-ends */
+	if (silence) {
+		close(STDOUT_FILENO);
+		close(STDERR_FILENO);
+	}
+
+	size_t i;
+	for (i = 0; i < hooks_n[event]; i++) {
+		command[2] = hooks[event][i];
+		pid_t pid = vfork();
+		if (pid == 0) {
+			execve("/bin/sh", command, environ);
+			exit(1);
+		}
+	}
+
+	exit(0);
+}
+
+int
+add_hook(int event, const char *action)
+{
+	size_t i = hooks_n[event]++;
+	hooks[event] = realloc(hooks[event], hooks_n[event] * sizeof(char*));
+	if (hooks[event] == NULL) {
+		perror("realloc");
+		return -1;
+	}
+	hooks[event][i] = strdup(action);
+	if (hooks[event][i] == NULL) {
+		perror("strdup");
+		return -1;
+	}
+	return 0;
+}
+
+void
+free_hooks(void)
+{
+	size_t i, j;
+	for (i = 0; i < 3; i++) {
+		for (j = 0; j < hooks_n[i]; j++) {
+			free(hooks[i][j]);
+		}
+		free(hooks[i]);
+	}
+}
+
+
+#else /* ! _WIN32 */
+
+
+void
+run_hooks(int event, int silence)
+{
+	(void) event;
+	(void) silence;
+}
+
+int
+add_hook(int event, const char *action)
+{
+	(void) event;
+	(void) action;
+	return 0;
+}
+
+void
+free_hooks(void)
+{
+	/* do nothing */
+}
+
+
+#endif /* ! _WIN32 */
+

--- a/src/hooks.h
+++ b/src/hooks.h
@@ -1,0 +1,35 @@
+/* redshift.h -- Main program header
+   This file is part of Redshift.
+
+   Redshift is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   Redshift is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with Redshift.  If not, see <http://www.gnu.org/licenses/>.
+
+   Copyright (c) 2014  Mattias Andrée <maandree@member.fsf.org>
+*/
+
+#ifndef REDSHIFT_HOOKS_H
+#define REDSHIFT_HOOKS_H
+
+
+#define HOOK_DAY  0
+#define HOOK_NIGHT  1
+#define HOOK_TWILIGHT  2
+
+
+
+void run_hooks(int event, int silence);
+int add_hook(int event, const char *action);
+void free_hooks(void);
+
+
+#endif /* ! REDSHIFT_HOOKS_H */


### PR DESCRIPTION
Implementation of https://bugs.launchpad.net/redshift/+bug/588087.

Usage:

Adding the following to `redshift.conf` will print
two texts saying what period of the day it is when
the transition barriers are reached as well as when
`redshift` starts.

``` ini
[hooks]
day=echo day
day=echo it is day
twilight=echo twilight
twilight=echo it is twilight
night=echo night
night=echo it is night
```

When redshift calculates that it is night, when it as twilight
the last time this calculation was done it will run the `night`
hooks asynchroniously. In this example it is
`sh -c "echo night"` and `sh -c "echo it is night"`.
