### PR TITLE
Added intltool to dependencies, as I got errors on ./bootstrap without it

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -48,6 +48,7 @@ Dependencies
 ------------
 
 * autotools, gettext
+* intltool
 * libdrm (Optional, for DRM support)
 * libxcb, libxcb-randr (Optional, for RandR support)
 * libX11, libXxf86vm (Optional, for VidMode support)


### PR DESCRIPTION
./bootstrap gave me the following output without this package:

```
autoreconf: Entering directory `.'
autoreconf: running: intltoolize --automake --copy --force
Can't exec "intltoolize": No such file or directory at /usr/share/autoconf/Autom4te/FileUtils.pm line 345.
autoreconf: failed to run intltoolize: No such file or directory
autoreconf: autopoint is needed because this package uses Gettext
```
