### PR TITLE
Add options to preserve existing gamma ramps

### DIFF
--- a/src/colorramp.c
+++ b/src/colorramp.c
@@ -297,9 +297,12 @@ colorramp_fill(uint16_t *gamma_r, uint16_t *gamma_g, uint16_t *gamma_b,
 			  &blackbody_color[temp_index+3], white_point);
 
 	for (int i = 0; i < size; i++) {
-		gamma_r[i] = F((float)i/size, 0) * (UINT16_MAX+1);
-		gamma_g[i] = F((float)i/size, 1) * (UINT16_MAX+1);
-		gamma_b[i] = F((float)i/size, 2) * (UINT16_MAX+1);
+		gamma_r[i] = F((double)gamma_r[i]/(UINT16_MAX+1), 0) *
+			(UINT16_MAX+1);
+		gamma_g[i] = F((double)gamma_g[i]/(UINT16_MAX+1), 1) *
+			(UINT16_MAX+1);
+		gamma_b[i] = F((double)gamma_b[i]/(UINT16_MAX+1), 2) *
+			(UINT16_MAX+1);
 	}
 }
 
@@ -315,9 +318,9 @@ colorramp_fill_float(float *gamma_r, float *gamma_g, float *gamma_b,
 			  &blackbody_color[temp_index+3], white_point);
 
 	for (int i = 0; i < size; i++) {
-		gamma_r[i] = F((float)i/size, 0);
-		gamma_g[i] = F((float)i/size, 1);
-		gamma_b[i] = F((float)i/size, 2);
+		gamma_r[i] = F((double)gamma_r[i], 0);
+		gamma_g[i] = F((double)gamma_g[i], 1);
+		gamma_b[i] = F((double)gamma_b[i], 2);
 	}
 }
 

--- a/src/gamma-drm.c
+++ b/src/gamma-drm.c
@@ -268,6 +268,16 @@ drm_set_temperature(drm_state_t *state, const color_setting_t *setting)
 			}
 			last_gamma_size = crtcs->gamma_size;
 		}
+
+		/* Initialize gamma ramps to pure state */
+		int ramp_size = crtcs->gamma_size;
+		for (int i = 0; i < ramp_size; i++) {
+			uint16_t value = (double)i/ramp_size * (UINT16_MAX+1);
+			r_gamma[i] = value;
+			g_gamma[i] = value;
+			b_gamma[i] = value;
+		}
+
 		colorramp_fill(r_gamma, g_gamma, b_gamma, crtcs->gamma_size,
 			       setting);
 		drmModeCrtcSetGamma(state->fd, crtcs->crtc_id, crtcs->gamma_size,

--- a/src/gamma-quartz.c
+++ b/src/gamma-quartz.c
@@ -96,6 +96,14 @@ quartz_set_temperature_for_display(CGDirectDisplayID display,
 	float *gamma_g = &gamma_ramps[1*ramp_size];
 	float *gamma_b = &gamma_ramps[2*ramp_size];
 
+	/* Initialize gamma ramps to pure state */
+	for (int i = 0; i < ramp_size; i++) {
+		float value = (double)i/ramp_size;
+		gamma_r[i] = value;
+		gamma_g[i] = value;
+		gamma_b[i] = value;
+	}
+
 	colorramp_fill_float(gamma_r, gamma_g, gamma_b, ramp_size,
 			     setting);
 

--- a/src/gamma-quartz.h
+++ b/src/gamma-quartz.h
@@ -20,11 +20,23 @@
 #ifndef REDSHIFT_GAMMA_QUARTZ_H
 #define REDSHIFT_GAMMA_QUARTZ_H
 
+#include <stdint.h>
+
+#include <ApplicationServices/ApplicationServices.h>
+
 #include "redshift.h"
 
 
 typedef struct {
-	int dummy;
+	CGDirectDisplayID display;
+	uint32_t ramp_size;
+	float *saved_ramps;
+} quartz_display_state_t;
+
+typedef struct {
+	quartz_display_state_t *displays;
+	uint32_t display_count;
+	int preserve;
 } quartz_state_t;
 
 

--- a/src/gamma-randr.c
+++ b/src/gamma-randr.c
@@ -51,6 +51,8 @@ randr_init(randr_state_t *state)
 	state->crtc_count = 0;
 	state->crtcs = NULL;
 
+	state->preserve = 0;
+
 	xcb_generic_error_t *error;
 
 	/* Open X server connection */
@@ -274,8 +276,11 @@ randr_print_help(FILE *f)
 
 	/* TRANSLATORS: RANDR help output
 	   left column must not be translated */
-	fputs(_("  screen=N\tX screen to apply adjustments to\n"
-		"  crtc=N\tCRTC to apply adjustments to\n"), f);
+	fputs(_("  screen=N\t\tX screen to apply adjustments to\n"
+		"  crtc=N\t\tCRTC to apply adjustments to\n"
+		"  preserve={0,1}\tWhether existing gamma should be"
+		" preserved\n"),
+	      f);
 	fputs("\n", f);
 }
 
@@ -286,6 +291,8 @@ randr_set_option(randr_state_t *state, const char *key, const char *value)
 		state->screen_num = atoi(value);
 	} else if (strcasecmp(key, "crtc") == 0) {
 		state->crtc_num = atoi(value);
+	} else if (strcasecmp(key, "preserve") == 0) {
+		state->preserve = atoi(value);
 	} else {
 		fprintf(stderr, _("Unknown method parameter: `%s'.\n"), key);
 		return -1;
@@ -327,12 +334,18 @@ randr_set_temperature_for_crtc(randr_state_t *state, int crtc_num,
 	uint16_t *gamma_g = &gamma_ramps[1*ramp_size];
 	uint16_t *gamma_b = &gamma_ramps[2*ramp_size];
 
-	/* Initialize gamma ramps to pure state */
-	for (int i = 0; i < ramp_size; i++) {
-		uint16_t value = (double)i/ramp_size * (UINT16_MAX+1);
-		gamma_r[i] = value;
-		gamma_g[i] = value;
-		gamma_b[i] = value;
+	if (state->preserve) {
+		/* Initialize gamma ramps from saved state */
+		memcpy(gamma_ramps, state->crtcs[crtc_num].saved_ramps,
+		       3*ramp_size*sizeof(uint16_t));
+	} else {
+		/* Initialize gamma ramps to pure state */
+		for (int i = 0; i < ramp_size; i++) {
+			uint16_t value = (double)i/ramp_size * (UINT16_MAX+1);
+			gamma_r[i] = value;
+			gamma_g[i] = value;
+			gamma_b[i] = value;
+		}
 	}
 
 	colorramp_fill(gamma_r, gamma_g, gamma_b, ramp_size,

--- a/src/gamma-randr.c
+++ b/src/gamma-randr.c
@@ -327,6 +327,14 @@ randr_set_temperature_for_crtc(randr_state_t *state, int crtc_num,
 	uint16_t *gamma_g = &gamma_ramps[1*ramp_size];
 	uint16_t *gamma_b = &gamma_ramps[2*ramp_size];
 
+	/* Initialize gamma ramps to pure state */
+	for (int i = 0; i < ramp_size; i++) {
+		uint16_t value = (double)i/ramp_size * (UINT16_MAX+1);
+		gamma_r[i] = value;
+		gamma_g[i] = value;
+		gamma_b[i] = value;
+	}
+
 	colorramp_fill(gamma_r, gamma_g, gamma_b, ramp_size,
 		       setting);
 

--- a/src/gamma-randr.h
+++ b/src/gamma-randr.h
@@ -39,6 +39,7 @@ typedef struct {
 	xcb_connection_t *conn;
 	xcb_screen_t *screen;
 	int preferred_screen;
+	int preserve;
 	int screen_num;
 	int crtc_num;
 	unsigned int crtc_count;

--- a/src/gamma-vidmode.c
+++ b/src/gamma-vidmode.c
@@ -180,6 +180,14 @@ vidmode_set_temperature(vidmode_state_t *state,
 	uint16_t *gamma_g = &gamma_ramps[1*state->ramp_size];
 	uint16_t *gamma_b = &gamma_ramps[2*state->ramp_size];
 
+	/* Initialize gamma ramps to pure state */
+	for (int i = 0; i < state->ramp_size; i++) {
+		uint16_t value = (double)i/state->ramp_size * (UINT16_MAX+1);
+		gamma_r[i] = value;
+		gamma_g[i] = value;
+		gamma_b[i] = value;
+	}
+
 	colorramp_fill(gamma_r, gamma_g, gamma_b, state->ramp_size,
 		       setting);
 

--- a/src/gamma-vidmode.c
+++ b/src/gamma-vidmode.c
@@ -43,6 +43,8 @@ vidmode_init(vidmode_state_t *state)
 	state->screen_num = -1;
 	state->saved_ramps = NULL;
 
+	state->preserve = 0;
+
 	/* Open display */
 	state->display = XOpenDisplay(NULL);
 	if (state->display == NULL) {
@@ -129,7 +131,10 @@ vidmode_print_help(FILE *f)
 
 	/* TRANSLATORS: VidMode help output
 	   left column must not be translated */
-	fputs(_("  screen=N\tX screen to apply adjustments to\n"), f);
+	fputs(_("  screen=N\t\tX screen to apply adjustments to\n"
+		"  preserve={0,1}\tWhether existing gamma should be"
+		" preserved\n"),
+	      f);
 	fputs("\n", f);
 }
 
@@ -138,6 +143,8 @@ vidmode_set_option(vidmode_state_t *state, const char *key, const char *value)
 {
 	if (strcasecmp(key, "screen") == 0) {
 		state->screen_num = atoi(value);
+	} else if (strcasecmp(key, "preserve") == 0) {
+		state->preserve = atoi(value);
 	} else {
 		fprintf(stderr, _("Unknown method parameter: `%s'.\n"), key);
 		return -1;
@@ -180,12 +187,19 @@ vidmode_set_temperature(vidmode_state_t *state,
 	uint16_t *gamma_g = &gamma_ramps[1*state->ramp_size];
 	uint16_t *gamma_b = &gamma_ramps[2*state->ramp_size];
 
-	/* Initialize gamma ramps to pure state */
-	for (int i = 0; i < state->ramp_size; i++) {
-		uint16_t value = (double)i/state->ramp_size * (UINT16_MAX+1);
-		gamma_r[i] = value;
-		gamma_g[i] = value;
-		gamma_b[i] = value;
+	if (state->preserve) {
+		/* Initialize gamma ramps from saved state */
+		memcpy(gamma_ramps, state->saved_ramps,
+		       3*state->ramp_size*sizeof(uint16_t));
+	} else {
+		/* Initialize gamma ramps to pure state */
+		for (int i = 0; i < state->ramp_size; i++) {
+			uint16_t value = (double)i/state->ramp_size *
+				(UINT16_MAX+1);
+			gamma_r[i] = value;
+			gamma_g[i] = value;
+			gamma_b[i] = value;
+		}
 	}
 
 	colorramp_fill(gamma_r, gamma_g, gamma_b, state->ramp_size,

--- a/src/gamma-vidmode.h
+++ b/src/gamma-vidmode.h
@@ -29,6 +29,7 @@
 
 typedef struct {
 	Display *display;
+	int preserve;
 	int screen_num;
 	int ramp_size;
 	uint16_t *saved_ramps;

--- a/src/gamma-w32gdi.c
+++ b/src/gamma-w32gdi.c
@@ -43,6 +43,7 @@ int
 w32gdi_init(w32gdi_state_t *state)
 {
 	state->saved_ramps = NULL;
+	state->preserve = 0;
 
 	return 0;
 }
@@ -102,12 +103,26 @@ w32gdi_print_help(FILE *f)
 {
 	fputs(_("Adjust gamma ramps with the Windows GDI.\n"), f);
 	fputs("\n", f);
+
+	/* TRANSLATORS: Windows GDI help output
+	   left column must not be translated */
+	fputs(_("  preserve={0,1}\tWhether existing gamma should be"
+		" preserved\n"),
+	      f);
+	fputs("\n", f);
 }
 
 int
 w32gdi_set_option(w32gdi_state_t *state, const char *key, const char *value)
 {
-	return -1;
+	if (strcasecmp(key, "preserve") == 0) {
+		state->preserve = atoi(value);
+	} else {
+		fprintf(stderr, _("Unknown method parameter: `%s'.\n"), key);
+		return -1;
+	}
+
+	return 0;
 }
 
 void
@@ -153,12 +168,19 @@ w32gdi_set_temperature(w32gdi_state_t *state,
 	WORD *gamma_g = &gamma_ramps[1*GAMMA_RAMP_SIZE];
 	WORD *gamma_b = &gamma_ramps[2*GAMMA_RAMP_SIZE];
 
-	/* Initialize gamma ramps to pure state */
-	for (int i = 0; i < GAMMA_RAMP_SIZE; i++) {
-		WORD value = (double)i/GAMMA_RAMP_SIZE * (UINT16_MAX+1);
-		gamma_r[i] = value;
-		gamma_g[i] = value;
-		gamma_b[i] = value;
+	if (state->preserve) {
+		/* Initialize gamma ramps from saved state */
+		memcpy(gamma_ramps, state->saved_ramps,
+		       3*GAMMA_RAMP_SIZE*sizeof(WORD));
+	} else {
+		/* Initialize gamma ramps to pure state */
+		for (int i = 0; i < GAMMA_RAMP_SIZE; i++) {
+			WORD value = (double)i/GAMMA_RAMP_SIZE *
+				(UINT16_MAX+1);
+			gamma_r[i] = value;
+			gamma_g[i] = value;
+			gamma_b[i] = value;
+		}
 	}
 
 	colorramp_fill(gamma_r, gamma_g, gamma_b, GAMMA_RAMP_SIZE,

--- a/src/gamma-w32gdi.c
+++ b/src/gamma-w32gdi.c
@@ -153,6 +153,14 @@ w32gdi_set_temperature(w32gdi_state_t *state,
 	WORD *gamma_g = &gamma_ramps[1*GAMMA_RAMP_SIZE];
 	WORD *gamma_b = &gamma_ramps[2*GAMMA_RAMP_SIZE];
 
+	/* Initialize gamma ramps to pure state */
+	for (int i = 0; i < GAMMA_RAMP_SIZE; i++) {
+		WORD value = (double)i/GAMMA_RAMP_SIZE * (UINT16_MAX+1);
+		gamma_r[i] = value;
+		gamma_g[i] = value;
+		gamma_b[i] = value;
+	}
+
 	colorramp_fill(gamma_r, gamma_g, gamma_b, GAMMA_RAMP_SIZE,
 		       setting);
 

--- a/src/gamma-w32gdi.h
+++ b/src/gamma-w32gdi.h
@@ -28,6 +28,7 @@
 
 typedef struct {
 	WORD *saved_ramps;
+	int preserve;
 } w32gdi_state_t;
 
 


### PR DESCRIPTION
This pull request adds options for most of the gamma adjustment methods to preserve the existing gamma ramps and modify these. This allows the user to set the gamma ramps before running Redshift and the effect will be preserved. For instance, some people have requested an option to invert the screen colors. This is now possible by first inverting the colors (e.g. `xcalib -invert -apply`) and then running Redshift with the `preserve` option set for the gamma adjustment method. A more common example would be a display where there is a color correction applied. Redshift will then base the redness effect on top of that correction.

- [ ] Check whether reset mode (`redshift -x`) still works (I suspect not), and decide how it should work when `preserve` is on.