### PR TITLE
fixes #157: it was a tiny oversight during refactoring

### DIFF
--- a/src/redshift.c
+++ b/src/redshift.c
@@ -1006,7 +1006,7 @@ run_continual_mode(const location_t *loc,
 
 		/* Adjust temperature */
 		if (!disabled || short_trans_delta || set_adjustments) {
-			r = method->set_temperature(&state, &interp);
+			r = method->set_temperature(state, &interp);
 			if (r < 0) {
 				fputs(_("Temperature adjustment"
 					" failed.\n"), stderr);
@@ -1028,7 +1028,7 @@ run_continual_mode(const location_t *loc,
 	}
 
 	/* Restore saved gamma ramps */
-	method->restore(&state);
+	method->restore(state);
 
 	return 0;
 }


### PR DESCRIPTION
No need to bother valgrind -- though I would love to know if it would have spotted the problem. I dug a bit deeper and found the culprit. At first I was wondering why the compiler was not complaining. But now I know:
```
typedef int gamma_method_set_temperature_func(void *state,
					      const color_setting_t *setting);
```
It does not know what to expect.

fixes #157