### PR TITLE
Added libtool as a dependency

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -48,7 +48,7 @@ Dependencies
 ------------
 
 * autotools, gettext
-* intltool
+* intltool, libtool
 * libdrm (Optional, for DRM support)
 * libxcb, libxcb-randr (Optional, for RandR support)
 * libX11, libXxf86vm (Optional, for VidMode support)


### PR DESCRIPTION
When I tried to build from source, ./bootstrap was giving me this error:

    autoreconf2.50: Entering directory `.'
    autoreconf2.50: running: intltoolize --automake --copy --force
    autoreconf2.50: running: aclocal --force -I m4
    autoreconf2.50: configure.ac: tracing
    autoreconf2.50: configure.ac: not using Libtool
    autoreconf2.50: running: /usr/bin/autoconf --force
    configure.ac:15: error: possibly undefined macro: AC_PROG_LIBTOOL
          If this token and others are legitimate, please use m4_pattern_allow.
          See the Autoconf documentation.
    autoreconf2.50: /usr/bin/autoconf failed with exit status: 1

I was able to fix this by installing libtool from the Debian repositories.  Therefore, I added it to the list in HACKING.md.