### PR TITLE
Fix clamp issues

### DIFF
--- a/src/redshift.c
+++ b/src/redshift.c
@@ -49,11 +49,6 @@
 #include "systemtime.h"
 #include "hooks.h"
 
-
-#define MIN(x,y)        ((x) < (y) ? (x) : (y))
-#define MAX(x,y)        ((x) > (y) ? (x) : (y))
-#define CLAMP(lo,x,up)  (MAX((lo), MIN((x), (up))))
-
 /* pause() is not defined on windows platform but is not needed either.
    Use a noop macro instead. */
 #ifdef __WIN32__
@@ -97,6 +92,8 @@
 # include "location-corelocation.h"
 #endif
 
+#undef CLAMP
+#define CLAMP(lo,mid,up)  (((lo) > (mid)) ? (lo) : (((mid) < (up)) ? (mid) : (up)))
 
 /* Union of state data for gamma adjustment methods */
 typedef union {
@@ -978,8 +975,7 @@ run_continual_mode(const location_t *loc,
 			}
 
 			/* Clamp alpha value */
-			adjustment_alpha =
-				MAX(0.0, MIN(adjustment_alpha, 1.0));
+			adjustment_alpha = CLAMP(0.0, adjustment_alpha, 1.0);
 		}
 
 		/* Interpolate between 6500K and calculated


### PR DESCRIPTION
Fixes #188

79aafd07fc49e09708d7475d7b3ccb19ede061b7 is a rewrite of christian-burger/redshift@c611b95ea0c47b459900929ba7828db2e006cec7

----
**Commit Messages:**
83bf2a37ad617372b9c5dc8ab83cf535afb66321

    Fix CLAMP macro by renaming it to BETWEEN

    Fixes #188

    When I moved the macro definition below all of the includes, I got the
    following compiler warning:

    /usr/include/glib-2.0/glib/gmacros.h:246:0: note: this is the location
    of the previous definition
     #define CLAMP(x, low, high)  (((x) > (high)) ? (high) : (((x) < (low))
    ? (low) : (x)))

    So, that's the macro definition that was being used whenever "CLAMP" was
    used. It's pretty obvious why that's wrong.

79aafd07fc49e09708d7475d7b3ccb19ede061b7

    Fix temperature getting out of bounds

    bug was introduced by refactoring at
    jonls/redshift@bb61a25e880827e5e0f75582b5303bcbb511d3c2

    elevation was allowed to sink or raise out of bounds of transition->low
    and transition->high which lead to rather funny colors when gamma
    exceeded its bounds too

