### PR TITLE
Use separate arguments instead of colon for option delimiting in -l and -m

### DIFF
--- a/redshift.1
+++ b/redshift.1
@@ -3,7 +3,7 @@
 redshift \- Set color temperature of display according to time of day.
 .SH SYNOPSIS
 .B redshift
-\fI[\-l LAT:LON | \-l PROVIDER:OPTIONS] [\-t DAY:NIGHT] \fR[\fIOPTIONS\fR...]
+\fI[\-l LAT:LON | \-l PROVIDER OPTIONS] [\-t DAY:NIGHT] \fR[\fIOPTIONS\fR...]
 .SH DESCRIPTION
 .B redshift
 adjusts the color temperature of your screen according to your
@@ -46,11 +46,11 @@ Your current location, in degrees, given as floating point numbers,
 towards north and east, with negative numbers representing south and
 west, respectively.
 .TP
-\fB\-l\fR PROVIDER[:OPTIONS]
+\fB\-l\fR PROVIDER [OPTIONS]
 Select provider for automatic location updates
 (Use `-l list' to see available providers)
 .TP
-\fB\-m\fR METHOD[:OPTIONS]
+\fB\-m\fR METHOD [OPTIONS]
 Method to use to set color temperature
 (Use `-m list' to see available methods)
 .TP

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -15,6 +15,7 @@ redshift_SOURCES = \
 	location-manual.c location-manual.h \
 	solar.c solar.h \
 	systemtime.c systemtime.h \
+	opt-parser.c opt-parser.h \
 	hooks.c hooks.h \
 	gamma-dummy.c gamma-dummy.h
 

--- a/src/opt-parser.c
+++ b/src/opt-parser.c
@@ -1,0 +1,79 @@
+/* opt-parser.c -- getopt wrapper source
+   This file is part of Redshift.
+
+   Redshift is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   Redshift is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with Redshift.  If not, see <http://www.gnu.org/licenses/>.
+
+   Copyright (c) 2014  Mattias Andrée <maandree@member.fsf.org>
+*/
+#include "opt-parser.h"
+
+#include <unistd.h>
+#include <stdlib.h>
+#include <string.h>
+
+
+int
+parseopt(int argc, char *const *argv, const char *shortopts, const char **args, int *args_count)
+{
+	int opt;
+	char *p;
+
+	*args_count = 0;
+	opt = getopt(argc, argv, shortopts);
+	if (opt < 0)
+		return opt;
+
+	p = strchr(shortopts, opt);
+	if ((p == NULL) || (p[1] != ':'))
+		return opt;
+
+	args[(*args_count)++] = optarg;
+	while (optind < argc && argv[optind][0] != '-') {
+		args[(*args_count)++] = argv[optind++];
+	}
+
+	return opt;
+}
+
+
+char *
+coalesce_args(const char *const *args, int args_count, char delimiter, char final)
+{
+	size_t n = args_count ? (args_count + 1) : 2;
+	size_t i;
+	char *rc;
+	char *rc_;
+
+	for (i = 0; i < args_count; i++)
+		n += strlen(args[i]);
+
+	rc = rc_ = malloc(n * sizeof(char));
+	if (rc == NULL)
+		return NULL;
+
+	for (i = 0; i < args_count; i++) {
+		n = strlen(args[i]);
+		memcpy(rc_, args[i], n * sizeof(char));
+		rc_ += n;
+		*rc_++ = delimiter;
+	}
+	if (args_count > 0)
+		rc_--;
+
+	*rc_++ = final;
+	*rc_++ = '\0';
+
+	return rc;
+}
+

--- a/src/opt-parser.h
+++ b/src/opt-parser.h
@@ -1,0 +1,28 @@
+/* opt-parser.h -- getopt wrapper header
+   This file is part of Redshift.
+
+   Redshift is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   Redshift is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with Redshift.  If not, see <http://www.gnu.org/licenses/>.
+
+   Copyright (c) 2014  Mattias Andrée <maandree@member.fsf.org>
+*/
+#ifndef REDSHIFT_OPT_PARSER_H
+#define REDSHIFT_OPT_PARSER_H
+
+
+int parseopt(int argc, char *const *argv, const char *shortopts, const char **args, int *args_count);
+
+char *coalesce_args(const char *const *args, int args_count, char delimiter, char final);
+
+
+#endif /* ! REDSHIFT_OPT_PARSER_H */

--- a/src/redshift.c
+++ b/src/redshift.c
@@ -521,7 +521,7 @@ print_method_list()
 	}
 
 	fputs("\n", stdout);
-	fputs(_("Specify colon-separated options with"
+	fputs(_("Specify space-separated options with"
 		" `-m METHOD OPTIONS'.\n"), stdout);
 	/* TRANSLATORS: `help' must not be translated. */
 	fputs(_("Try `-m METHOD help' for help.\n"), stdout);
@@ -536,7 +536,7 @@ print_provider_list()
 	}
 
 	fputs("\n", stdout);
-	fputs(_("Specify colon-separated options with"
+	fputs(_("Specify space-separated options with"
 		"`-l PROVIDER OPTIONS'.\n"), stdout);
 	/* TRANSLATORS: `help' must not be translated. */
 	fputs(_("Try `-l PROVIDER help' for help.\n"), stdout);


### PR DESCRIPTION
As discussed way back. Colon is problematic in -m, and separate arguments is a better solution that will not cause problems in the future. The same change is applied -l, so they work in the same way.
