### PR TITLE
Add -T flag to toggle Redshift

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -53,6 +53,7 @@ Dependencies
 * libxcb, libxcb-randr (Optional, for RandR support)
 * libX11, libXxf86vm (Optional, for VidMode support)
 * geoclue (Optional, for geoclue support)
+* procps (Optional, for `redshift -T` support)
 
 * python3, pygobject, pyxdg (Optional, for GUI support)
 * appindicator (Optional, for Ubuntu-style GUI status icon)

--- a/redshift.1
+++ b/redshift.1
@@ -32,6 +32,9 @@ Verbose output
 \fB\-V\fR
 Show program version
 .TP
+\fB\-T\fR
+Activate or deactivate running instances of Redshift
+.TP
 \fB\-b\fR DAY:NIGHT
 Screen brightness to apply (between 0.1 and 1.0)
 .TP

--- a/src/redshift.c
+++ b/src/redshift.c
@@ -300,7 +300,8 @@ typedef enum {
 	PROGRAM_MODE_ONE_SHOT,
 	PROGRAM_MODE_PRINT,
 	PROGRAM_MODE_RESET,
-	PROGRAM_MODE_MANUAL
+	PROGRAM_MODE_MANUAL,
+	PROGRAM_MODE_TOGGLE
 } program_mode_t;
 
 /* Transition scheme.
@@ -1088,7 +1089,7 @@ main(int argc, char *argv[])
 
 	/* Parse command line arguments. */
 	int opt;
-	while ((opt = getopt(argc, argv, "b:c:g:hl:m:oO:prt:vVx")) != -1) {
+	while ((opt = getopt(argc, argv, "b:c:g:hl:m:oO:prt:TvVx")) != -1) {
 		switch (opt) {
 		case 'b':
 			parse_brightness_string(optarg,
@@ -1220,6 +1221,9 @@ main(int argc, char *argv[])
 			scheme.day.temperature = atoi(optarg);
 			scheme.night.temperature = atoi(s);
 			break;
+		case 'T':
+			mode = PROGRAM_MODE_TOGGLE;
+			break;
 		case 'v':
 			verbose = 1;
 			break;
@@ -1235,6 +1239,16 @@ main(int argc, char *argv[])
 			exit(EXIT_FAILURE);
 			break;
 		}
+	}
+
+	/* Activate or deactivle Redshift. */
+	if (mode == PROGRAM_MODE_TOGGLE) {
+		char user[3 * sizeof(uid_t) + 1];
+		uid_t uid = getuid();
+		sprintf(user, "%ji", (intmax_t)uid);
+		execlp("pkill", "pkill", "-USR1", "-u", user, "^redshift$", NULL);
+		perror("execlp");
+		exit(EXIT_FAILURE);
 	}
 
 	/* Load settings from config file. */

--- a/src/redshift.c
+++ b/src/redshift.c
@@ -484,6 +484,7 @@ print_help(const char *program_name)
 		"  -O TEMP\tOne shot manual mode (set color temperature)\n"
 		"  -p\t\tPrint mode (only print parameters and exit)\n"
 		"  -x\t\tReset mode (remove adjustment from screen)\n"
+		"  -T\t\tToggle mode (activate or deactivate redshift)\n"
 		"  -r\t\tDisable temperature transitions\n"
 		"  -t DAY:NIGHT\tColor temperature to set at daytime/night\n"),
 	      stdout);


### PR DESCRIPTION
This patch as the flag `-T` it redshift. When used, the started process exec:s to `pkill` to send USR1 to all running instances of Redshift owned by the current user.
