### PR TITLE
Specify required Gtk version

### DIFF
--- a/src/redshift-gtk/statusicon.py
+++ b/src/redshift-gtk/statusicon.py
@@ -29,6 +29,9 @@ import signal
 import re
 import gettext
 
+import gi
+gi.require_version('Gtk', '3.0')
+
 from gi.repository import Gtk, GLib, GObject
 
 try:


### PR DESCRIPTION
This fixes a warning when starting redshift-gtk with gtk 3.18.