### PR TITLE
Specify autopoint as a dependency

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -47,7 +47,7 @@ $ $HOME/redshift/root/bin/redshift-gtk
 Dependencies
 ------------
 
-* autotools, gettext
+* autotools, gettext, autopoint
 * intltool, libtool
 * libdrm (Optional, for DRM support)
 * libxcb, libxcb-randr (Optional, for RandR support)


### PR DESCRIPTION
Noticed autopoint is an unspecified dependency in HACKING.md

You cannot seem to run `./bootstrap` without it:

```
$ ./bootstrap
./bootstrap: 6: ./bootstrap: autopoint: not found
```

Tested on a relatively fresh install of Ubuntu 15.10