### PR TITLE
Add dbus "gamma" driver

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,11 @@ before_install:
   - sudo apt-get update -qq
 install:
   - sudo apt-get install -qq autopoint intltool
+  - sudo apt-get install -qq libdbus-1-dev
   - sudo apt-get install -qq libdrm-dev
   - sudo apt-get install -qq libxcb1-dev libxcb-randr0-dev
   - sudo apt-get install -qq libx11-dev libxxf86vm-dev
   - sudo apt-get install -qq libgeoclue-dev
   - sudo apt-get install -qq libglib2.0-dev
   - sudo apt-get install -qq python3
-script: ./bootstrap && ./configure --enable-drm --enable-vidmode --enable-randr --enable-geoclue --enable-geoclue2 --enable-gui && make -j2 distcheck
+script: ./bootstrap && ./configure --enable-dbus --enable-drm --enable-vidmode --enable-randr --enable-geoclue --enable-geoclue2 --enable-gui && make -j2 distcheck

--- a/README-dbus.md
+++ b/README-dbus.md
@@ -1,0 +1,76 @@
+# DBus gamma provider for Redshift #
+
+This provider emits colour temperature values onto DBus.
+
+This can then be used to export the colour ramping features of Redshift into another application.  An example application of this would be a program to change the colour temperature of network-controllable lighting.
+
+## Building Redshift to support DBus
+
+Redshift will require that you install the DBus headers.  This is normally in a development package in your package manager, named something like `libdbus-1-dev`.
+
+In order to build Redshift with DBus support, run the following:
+
+```
+./bootstrap
+./configure --enable-dbus
+make -j2
+make install
+```
+
+### Running without Xorg / X11
+
+You may wish to supply additional arguments to `./configure` in order to disable other gamma providers, if you are running Redshift on a system without Xorg:
+
+```
+./configure --enable-dbus --disable-drm --disable-randr --disable-vidmode --disable-quartz --disable-wingdi --disable-gui --disable-ubuntu
+```
+
+Note: you may execute with `--disable-ubuntu`, even if you are installing on Ubuntu Server.  This installs extra icons which are only relevant to systems with Xorg.
+
+### Configuring DBus to permit a user to broadcast on the System bus
+
+Normally, DBus will prohibit users from broadcasting to the System bus.  You can add a file like `/etc/dbus-1/system.d/redshift.conf` to change the permissions:
+
+```xml
+<!DOCTYPE busconfig PUBLIC "-//freedesktop//DTD D-BUS Bus Configuration 1.0//EN" "http://www.freedesktop.org/standards/dbus/1.0/busconfig.dtd">
+<busconfig>
+	<policy user="redshift"> <!-- This is the user redshift runs as. -->
+		<allow own="dk.jonls.redshift.dbus"/>
+		<allow send_destination="dk.jonls.redshift.dbus" send_interface="dk.jonls.Redshift"/>
+		<allow send_destination="dk.jonls.redshift.dbus" send_interface="org.freedesktop.DBus.Introspectable"/>
+	</policy>
+</busconfig>
+```
+
+## Running Redshift to support DBus
+
+If you're running headless, you probably don't have extra desktop geolocation providers like Geoclue avaliable.  You'll need to manually enter your location, in latitude and longitude, as a parameter to Redshift.
+
+You can choose whether you want to run on the System or the Session bus.  You'll need to write some extra configuration for your DBus daemon in order to permit this.
+
+For example, if you live in Sydney, Australia, and want to emit messages on the System bus, you would run Redshift with the following command:
+
+```
+redshift -m dbus -l -33.867716:151.207699
+```
+
+If you want to instead emit these messages on the Session bus (useful for local testing):
+
+```
+redshift -m dbus:session=1 -l -33.867716:151.207699
+```
+
+## DBus signals format
+
+Redshift will emit messages from `dk.jonls.redshift.dbus` to `/dk/jonls/Redshift`, with the `dk.jonls.Redshift` interface.
+
+You can test this with `mdbus2` with the following:
+
+```
+mdbus2 -s -l dk.jonls.redshift.dbus
+```
+
+Omit the `-s` option to work with the Session bus rather than the System bus.
+
+The signals will be of type `dk.jonls.Redshift.Temperature`, which takes a single int16 argument, the desired colour temperature.
+

--- a/README-dbus.md
+++ b/README-dbus.md
@@ -64,13 +64,22 @@ redshift -m dbus:session=1 -l -33.867716:151.207699
 
 Redshift will emit messages from `dk.jonls.redshift.dbus` to `/dk/jonls/Redshift`, with the `dk.jonls.Redshift` interface.
 
-You can test this with `mdbus2` with the following:
+You can test it with `dbus-monitor` wth the following:
+
+```
+dbus-monitor --system "type='signal',sender='dk.jonls.redshift.dbus',interface='dk.jonls.Redshift'"
+```
+
+Or with `mdbus2` with the following:
 
 ```
 mdbus2 -s -l dk.jonls.redshift.dbus
 ```
 
-Omit the `-s` option to work with the Session bus rather than the System bus.
+The signals will be of type `dk.jonls.Redshift.Temperature`, which takes a single int16 argument, the desired colour temperature:
 
-The signals will be of type `dk.jonls.Redshift.Temperature`, which takes a single int16 argument, the desired colour temperature.
+```
+signal sender=:1.3738 -> dest=(null destination) serial=102 path=/dk/jonls/Redshift; interface=dk.jonls.Redshift; member=Temperature
+   int16 5500
+```
 

--- a/configure.ac
+++ b/configure.ac
@@ -50,6 +50,7 @@ PKG_CHECK_MODULES([XCB_RANDR], [xcb-randr],
 PKG_CHECK_MODULES([GLIB], [glib-2.0 gobject-2.0], [have_glib=yes], [have_glib=no])
 PKG_CHECK_MODULES([GEOCLUE], [geoclue], [have_geoclue=yes], [have_geoclue=no])
 PKG_CHECK_MODULES([GEOCLUE2], [glib-2.0 gio-2.0 >= 2.26], [have_geoclue2=yes], [have_geoclue2=no])
+PKG_CHECK_MODULES([DBUS], [dbus-1], [have_dbus=yes], [have_dbus=no])
 
 # OSX headers
 AC_CHECK_HEADER([ApplicationServices/ApplicationServices.h], [have_appserv_h=yes], [have_appserv_h=no])
@@ -79,6 +80,30 @@ AC_CHECK_HEADER([windows.h], [have_windows_h=yes], [have_windows_h=no])
 
 # Check for Python
 AM_PATH_PYTHON([3.2], [have_python=yes], [have_python=no])
+
+# Check DBUS method
+AC_MSG_CHECKING([whether to enable DBUS method])
+AC_ARG_ENABLE([dbus], [AC_HELP_STRING([--enable-dbus],
+	[enable DBUS method])],
+	[enable_dbus=$enableval],[enable_dbus=maybe])
+AS_IF([test "x$enable_dbus" != xno], [
+	AS_IF([test $have_dbus = yes], [
+		AC_DEFINE([ENABLE_DBUS], 1,
+			[Define to 1 to enable DBUS method])
+		AC_MSG_RESULT([yes])
+		enable_dbus=yes
+	], [
+		AC_MSG_RESULT([missing dependencies])
+		AS_IF([test "x$enable_dbus" = xyes], [
+			AC_MSG_ERROR([missing dependencies for DBUS method])
+		])
+		enable_dbus=no
+	])
+], [
+	AC_MSG_RESULT([no])
+	enable_dbus=no
+])
+AM_CONDITIONAL([ENABLE_DBUS], [test "x$enable_dbus" = xyes])
 
 # Check DRM method
 AC_MSG_CHECKING([whether to enable DRM method])
@@ -364,6 +389,7 @@ echo "
     ldflags:		${LDFLAGS}
 
     Adjustment methods:
+    DBUS:		${enable_dbus}
     DRM:		${enable_drm}
     RANDR:		${enable_randr}
     VidMode:		${enable_vidmode}

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -8,6 +8,7 @@ src/redshift.c
 
 src/config-ini.c
 
+src/gamma-dbus.c
 src/gamma-drm.c
 src/gamma-randr.c
 src/gamma-vidmode.c

--- a/po/redshift.pot
+++ b/po/redshift.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: https://github.com/jonls/redshift/issues\n"
-"POT-Creation-Date: 2015-02-22 11:23-0500\n"
+"POT-Creation-Date: 2016-01-04 01:11+1100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -43,69 +43,72 @@ msgid ""
 "effect"
 msgstr ""
 
+#: ../data/applications/redshift.desktop.in.h:1
 #: ../data/applications/redshift-gtk.desktop.in.h:1
 msgid "Redshift"
 msgstr ""
 
+#: ../data/applications/redshift.desktop.in.h:2
 #: ../data/applications/redshift-gtk.desktop.in.h:2
 msgid "Color temperature adjustment"
 msgstr ""
 
+#: ../data/applications/redshift.desktop.in.h:3
 #: ../data/applications/redshift-gtk.desktop.in.h:3
 msgid "Color temperature adjustment tool"
 msgstr ""
 
 #. TRANSLATORS: Name printed when period of day is unknown
-#: ../src/redshift.c:319
+#: ../src/redshift.c:337
 msgid "None"
 msgstr ""
 
-#: ../src/redshift.c:320 ../src/redshift.c:1546
+#: ../src/redshift.c:338 ../src/redshift.c:1496
 msgid "Daytime"
 msgstr ""
 
-#: ../src/redshift.c:321 ../src/redshift.c:1549
+#: ../src/redshift.c:339 ../src/redshift.c:1499
 msgid "Night"
 msgstr ""
 
-#: ../src/redshift.c:322
+#: ../src/redshift.c:340
 msgid "Transition"
 msgstr ""
 
-#: ../src/redshift.c:389
+#: ../src/redshift.c:381
 #, c-format
 msgid "Period: %s\n"
 msgstr ""
 
-#: ../src/redshift.c:392
+#: ../src/redshift.c:384
 #, c-format
 msgid "Period: %s (%.2f%% day)\n"
 msgstr ""
 
 #. TRANSLATORS: Abbreviation for `north'
-#: ../src/redshift.c:404
+#: ../src/redshift.c:396
 msgid "N"
 msgstr ""
 
 #. TRANSLATORS: Abbreviation for `south'
-#: ../src/redshift.c:406
+#: ../src/redshift.c:398
 msgid "S"
 msgstr ""
 
 #. TRANSLATORS: Abbreviation for `east'
-#: ../src/redshift.c:408
+#: ../src/redshift.c:400
 msgid "E"
 msgstr ""
 
 #. TRANSLATORS: Abbreviation for `west'
-#: ../src/redshift.c:410
+#: ../src/redshift.c:402
 msgid "W"
 msgstr ""
 
 #. TRANSLATORS: Append degree symbols after %f if possible.
 #. The string following each number is an abreviation for
 #. north, source, east or west (N, S, E, W).
-#: ../src/redshift.c:415
+#: ../src/redshift.c:407
 #, c-format
 msgid "Location: %.2f %s, %.2f %s\n"
 msgstr ""
@@ -115,20 +118,20 @@ msgstr ""
 #. DAY is temperature at daytime,
 #. NIGHT is temperature at night
 #. no-wrap
-#: ../src/redshift.c:452
+#: ../src/redshift.c:444
 #, c-format
 msgid "Usage: %s -l LAT:LON -t DAY:NIGHT [OPTIONS...]\n"
 msgstr ""
 
 #. TRANSLATORS: help output 2
 #. no-wrap
-#: ../src/redshift.c:458
+#: ../src/redshift.c:450
 msgid "Set color temperature of display according to time of day.\n"
 msgstr ""
 
 #. TRANSLATORS: help output 3
 #. no-wrap
-#: ../src/redshift.c:464
+#: ../src/redshift.c:456
 msgid ""
 "  -h\t\tDisplay this help message\n"
 "  -v\t\tVerbose output\n"
@@ -138,7 +141,7 @@ msgstr ""
 #. TRANSLATORS: help output 4
 #. `list' must not be translated
 #. no-wrap
-#: ../src/redshift.c:472
+#: ../src/redshift.c:464
 msgid ""
 "  -b DAY:NIGHT\tScreen brightness to apply (between 0.1 and 1.0)\n"
 "  -c FILE\tLoad settings from specified configuration file\n"
@@ -157,7 +160,7 @@ msgid ""
 msgstr ""
 
 #. TRANSLATORS: help output 5
-#: ../src/redshift.c:492
+#: ../src/redshift.c:484
 #, c-format
 msgid ""
 "The neutral temperature is %uK. Using this value will not\n"
@@ -168,7 +171,7 @@ msgid ""
 msgstr ""
 
 #. TRANSLATORS: help output 6
-#: ../src/redshift.c:502
+#: ../src/redshift.c:494
 #, c-format
 msgid ""
 "Default values:\n"
@@ -178,44 +181,44 @@ msgid ""
 msgstr ""
 
 #. TRANSLATORS: help output 7
-#: ../src/redshift.c:510
+#: ../src/redshift.c:502
 #, c-format
 msgid "Please report bugs to <%s>\n"
 msgstr ""
 
-#: ../src/redshift.c:516
+#: ../src/redshift.c:508
 msgid "Available adjustment methods:\n"
 msgstr ""
 
-#: ../src/redshift.c:522
+#: ../src/redshift.c:514
 msgid "Specify colon-separated options with `-m METHOD:OPTIONS'.\n"
 msgstr ""
 
 #. TRANSLATORS: `help' must not be translated.
-#: ../src/redshift.c:525
+#: ../src/redshift.c:517
 msgid "Try `-m METHOD:help' for help.\n"
 msgstr ""
 
-#: ../src/redshift.c:531
+#: ../src/redshift.c:523
 msgid "Available location providers:\n"
 msgstr ""
 
-#: ../src/redshift.c:537
+#: ../src/redshift.c:529
 msgid "Specify colon-separated options with`-l PROVIDER:OPTIONS'.\n"
 msgstr ""
 
 #. TRANSLATORS: `help' must not be translated.
-#: ../src/redshift.c:540
+#: ../src/redshift.c:532
 msgid "Try `-l PROVIDER:help' for help.\n"
 msgstr ""
 
-#: ../src/redshift.c:553 ../src/redshift.c:645
+#: ../src/redshift.c:545 ../src/redshift.c:637
 #, c-format
 msgid "Initialization of %s failed.\n"
 msgstr ""
 
-#: ../src/redshift.c:568 ../src/redshift.c:612 ../src/redshift.c:660
-#: ../src/redshift.c:692
+#: ../src/redshift.c:560 ../src/redshift.c:604 ../src/redshift.c:652
+#: ../src/redshift.c:684
 #, c-format
 msgid "Failed to set %s option.\n"
 msgstr ""
@@ -223,202 +226,202 @@ msgstr ""
 #. TRANSLATORS: `help' must not be
 #. translated.
 #. TRANSLATORS: `help' must not be translated.
-#: ../src/redshift.c:573 ../src/redshift.c:615
+#: ../src/redshift.c:565 ../src/redshift.c:607
 #, c-format
 msgid "Try `-l %s:help' for more information.\n"
 msgstr ""
 
-#: ../src/redshift.c:601 ../src/redshift.c:682
+#: ../src/redshift.c:593 ../src/redshift.c:674
 #, c-format
 msgid "Failed to parse option `%s'.\n"
 msgstr ""
 
-#: ../src/redshift.c:628
+#: ../src/redshift.c:620
 #, c-format
 msgid "Failed to start provider %s.\n"
 msgstr ""
 
 #. TRANSLATORS: `help' must not be
 #. translated.
-#: ../src/redshift.c:665
+#: ../src/redshift.c:657
 #, c-format
 msgid "Try `-m %s:help' for more information.\n"
 msgstr ""
 
 #. TRANSLATORS: `help' must not be translated.
-#: ../src/redshift.c:695
+#: ../src/redshift.c:687
 #, c-format
 msgid "Try -m %s:help' for more information.\n"
 msgstr ""
 
-#: ../src/redshift.c:707
+#: ../src/redshift.c:699
 #, c-format
 msgid "Failed to start adjustment method %s.\n"
 msgstr ""
 
-#: ../src/redshift.c:870 ../src/redshift.c:898
+#: ../src/redshift.c:821 ../src/redshift.c:849
 #, c-format
 msgid "Status: %s\n"
 msgstr ""
 
-#: ../src/redshift.c:870 ../src/redshift.c:899
-#: ../src/redshift-gtk/statusicon.py:260 ../src/redshift-gtk/statusicon.py:466
+#: ../src/redshift.c:821 ../src/redshift.c:850
+#: ../src/redshift-gtk/statusicon.py:266 ../src/redshift-gtk/statusicon.py:472
 msgid "Enabled"
 msgstr ""
 
-#: ../src/redshift.c:899 ../src/redshift-gtk/statusicon.py:466
+#: ../src/redshift.c:850 ../src/redshift-gtk/statusicon.py:472
 msgid "Disabled"
 msgstr ""
 
-#: ../src/redshift.c:927 ../src/redshift.c:1600
+#: ../src/redshift.c:878 ../src/redshift.c:1550
 msgid "Unable to read system time.\n"
 msgstr ""
 
-#: ../src/redshift.c:999 ../src/redshift.c:1623 ../src/redshift.c:1652
+#: ../src/redshift.c:949 ../src/redshift.c:1573 ../src/redshift.c:1602
 #, c-format
 msgid "Color temperature: %uK\n"
 msgstr ""
 
-#: ../src/redshift.c:1004 ../src/redshift.c:1625
+#: ../src/redshift.c:954 ../src/redshift.c:1575
 #, c-format
 msgid "Brightness: %.2f\n"
 msgstr ""
 
-#: ../src/redshift.c:1013 ../src/redshift.c:1636 ../src/redshift.c:1660
-#: ../src/redshift.c:1680
+#: ../src/redshift.c:963 ../src/redshift.c:1586 ../src/redshift.c:1610
+#: ../src/redshift.c:1630
 msgid "Temperature adjustment failed.\n"
 msgstr ""
 
-#: ../src/redshift.c:1105
+#: ../src/redshift.c:1055
 msgid "Malformed gamma argument.\n"
 msgstr ""
 
-#: ../src/redshift.c:1107 ../src/redshift.c:1215 ../src/redshift.c:1234
+#: ../src/redshift.c:1057 ../src/redshift.c:1165 ../src/redshift.c:1184
 msgid "Try `-h' for more information.\n"
 msgstr ""
 
-#: ../src/redshift.c:1154 ../src/redshift.c:1355
+#: ../src/redshift.c:1104 ../src/redshift.c:1305
 #, c-format
 msgid "Unknown location provider `%s'.\n"
 msgstr ""
 
 #. TRANSLATORS: This refers to the method
 #. used to adjust colors e.g VidMode
-#: ../src/redshift.c:1185 ../src/redshift.c:1341
+#: ../src/redshift.c:1135 ../src/redshift.c:1291
 #, c-format
 msgid "Unknown adjustment method `%s'.\n"
 msgstr ""
 
-#: ../src/redshift.c:1213
+#: ../src/redshift.c:1163
 msgid "Malformed temperature argument.\n"
 msgstr ""
 
-#: ../src/redshift.c:1305 ../src/redshift.c:1318 ../src/redshift.c:1329
+#: ../src/redshift.c:1255 ../src/redshift.c:1268 ../src/redshift.c:1279
 msgid "Malformed gamma setting.\n"
 msgstr ""
 
-#: ../src/redshift.c:1364
+#: ../src/redshift.c:1314
 #, c-format
 msgid "Unknown configuration setting `%s'.\n"
 msgstr ""
 
-#: ../src/redshift.c:1422
+#: ../src/redshift.c:1372
 #, c-format
 msgid "Trying location provider `%s'...\n"
 msgstr ""
 
-#: ../src/redshift.c:1427
+#: ../src/redshift.c:1377
 msgid "Trying next provider...\n"
 msgstr ""
 
-#: ../src/redshift.c:1433
+#: ../src/redshift.c:1383
 #, c-format
 msgid "Using provider `%s'.\n"
 msgstr ""
 
-#: ../src/redshift.c:1441
+#: ../src/redshift.c:1391
 msgid "No more location providers to try.\n"
 msgstr ""
 
-#: ../src/redshift.c:1450
+#: ../src/redshift.c:1400
 msgid "Unable to get location from provider.\n"
 msgstr ""
 
-#: ../src/redshift.c:1460
+#: ../src/redshift.c:1410
 #, c-format
 msgid "Temperatures: %dK at day, %dK at night\n"
 msgstr ""
 
 #. TRANSLATORS: Append degree symbols if possible.
-#: ../src/redshift.c:1465
+#: ../src/redshift.c:1415
 #, c-format
 msgid "Solar elevations: day above %.1f, night below %.1f\n"
 msgstr ""
 
-#: ../src/redshift.c:1473
+#: ../src/redshift.c:1423
 #, c-format
 msgid "Latitude must be between %.1f and %.1f.\n"
 msgstr ""
 
-#: ../src/redshift.c:1482
+#: ../src/redshift.c:1432
 #, c-format
 msgid "Longitude must be between %.1f and %.1f.\n"
 msgstr ""
 
-#: ../src/redshift.c:1493 ../src/redshift.c:1511
+#: ../src/redshift.c:1443 ../src/redshift.c:1461
 #, c-format
 msgid "Temperature must be between %uK and %uK.\n"
 msgstr ""
 
-#: ../src/redshift.c:1501
+#: ../src/redshift.c:1451
 #, c-format
 msgid ""
 "High transition elevation cannot be lower than the low transition "
 "elevation.\n"
 msgstr ""
 
-#: ../src/redshift.c:1523
+#: ../src/redshift.c:1473
 #, c-format
 msgid "Brightness values must be between %.1f and %.1f.\n"
 msgstr ""
 
-#: ../src/redshift.c:1529
+#: ../src/redshift.c:1479
 #, c-format
 msgid "Brightness: %.2f:%.2f\n"
 msgstr ""
 
-#: ../src/redshift.c:1537
+#: ../src/redshift.c:1487
 #, c-format
 msgid "Gamma value must be between %.1f and %.1f.\n"
 msgstr ""
 
 #. TRANSLATORS: The string in parenthesis is either
 #. Daytime or Night (translated).
-#: ../src/redshift.c:1545 ../src/redshift.c:1548
+#: ../src/redshift.c:1495 ../src/redshift.c:1498
 #, c-format
 msgid "Gamma (%s): %.3f, %.3f, %.3f\n"
 msgstr ""
 
-#: ../src/redshift.c:1572
+#: ../src/redshift.c:1522
 msgid "Trying next method...\n"
 msgstr ""
 
-#: ../src/redshift.c:1577
+#: ../src/redshift.c:1527
 #, c-format
 msgid "Using method `%s'.\n"
 msgstr ""
 
-#: ../src/redshift.c:1584
+#: ../src/redshift.c:1534
 msgid "No more methods to try.\n"
 msgstr ""
 
 #. TRANSLATORS: Append degree symbol if possible.
-#: ../src/redshift.c:1609
+#: ../src/redshift.c:1559
 #, c-format
 msgid "Solar elevation: %f\n"
 msgstr ""
 
-#: ../src/redshift.c:1645 ../src/redshift.c:1669 ../src/redshift.c:1689
+#: ../src/redshift.c:1595 ../src/redshift.c:1619 ../src/redshift.c:1639
 msgid "Press ctrl-c to stop...\n"
 msgstr ""
 
@@ -432,6 +435,55 @@ msgstr ""
 
 #: ../src/config-ini.c:214
 msgid "Assignment outside section in config file.\n"
+msgstr ""
+
+#: ../src/gamma-dbus.c:55
+#, c-format
+msgid "DBus connection error (%s)\n"
+msgstr ""
+
+#: ../src/gamma-dbus.c:66
+#, c-format
+msgid "DBus name error (%s)\n"
+msgstr ""
+
+#: ../src/gamma-dbus.c:90
+msgid "Select where to send signals to dbus.\n"
+msgstr ""
+
+#. TRANSLATORS: DBUS help output
+#. left column must not be translated
+#: ../src/gamma-dbus.c:95
+msgid "  session=1\tSend messages to the session instead of system bus\n"
+msgstr ""
+
+#: ../src/gamma-dbus.c:105
+#, c-format
+msgid "session must be either 0 (use system bus) or 1 (use session bus)\n"
+msgstr ""
+
+#: ../src/gamma-dbus.c:109 ../src/gamma-drm.c:235 ../src/gamma-randr.c:297
+#: ../src/gamma-vidmode.c:149 ../src/gamma-quartz.c:172
+#: ../src/gamma-w32gdi.c:121 ../src/gamma-dummy.c:66
+#: ../src/location-geoclue.c:180 ../src/location-geoclue2.c:82
+#: ../src/location-corelocation.m:141 ../src/location-manual.c:96
+#, c-format
+msgid "Unknown method parameter: `%s'.\n"
+msgstr ""
+
+#: ../src/gamma-dbus.c:125
+#, c-format
+msgid "DBus message is null\n"
+msgstr ""
+
+#: ../src/gamma-dbus.c:132
+#, c-format
+msgid "Out of memory!\n"
+msgstr ""
+
+#: ../src/gamma-dbus.c:138
+#, c-format
+msgid "Failed to send DBus message\n"
 msgstr ""
 
 #: ../src/gamma-drm.c:78
@@ -473,29 +525,21 @@ msgid ""
 "graphics card %i, ignoring device.\n"
 msgstr ""
 
-#: ../src/gamma-drm.c:214
+#: ../src/gamma-drm.c:213
 msgid "Adjust gamma ramps with Direct Rendering Manager.\n"
 msgstr ""
 
 #. TRANSLATORS: DRM help output
 #. left column must not be translated
-#: ../src/gamma-drm.c:219
+#: ../src/gamma-drm.c:218
 msgid ""
 "  card=N\tGraphics card to apply adjustments to\n"
 "  crtc=N\tCRTC to apply adjustments to\n"
 msgstr ""
 
-#: ../src/gamma-drm.c:232
+#: ../src/gamma-drm.c:231
 #, c-format
 msgid "CRTC must be a non-negative integer\n"
-msgstr ""
-
-#: ../src/gamma-drm.c:236 ../src/gamma-randr.c:297 ../src/gamma-vidmode.c:149
-#: ../src/gamma-quartz.c:172 ../src/gamma-w32gdi.c:121 ../src/gamma-dummy.c:66
-#: ../src/location-geoclue.c:180 ../src/location-geoclue2.c:82
-#: ../src/location-corelocation.m:141 ../src/location-manual.c:96
-#, c-format
-msgid "Unknown method parameter: `%s'.\n"
 msgstr ""
 
 #: ../src/gamma-randr.c:72 ../src/gamma-randr.c:129 ../src/gamma-randr.c:168
@@ -764,50 +808,50 @@ msgstr ""
 msgid "Malformed argument.\n"
 msgstr ""
 
-#: ../src/redshift-gtk/statusicon.py:265
+#: ../src/redshift-gtk/statusicon.py:271
 msgid "Suspend for"
 msgstr ""
 
-#: ../src/redshift-gtk/statusicon.py:267
+#: ../src/redshift-gtk/statusicon.py:273
 msgid "30 minutes"
 msgstr ""
 
-#: ../src/redshift-gtk/statusicon.py:268
+#: ../src/redshift-gtk/statusicon.py:274
 msgid "1 hour"
 msgstr ""
 
-#: ../src/redshift-gtk/statusicon.py:269
+#: ../src/redshift-gtk/statusicon.py:275
 msgid "2 hours"
 msgstr ""
 
-#: ../src/redshift-gtk/statusicon.py:277
+#: ../src/redshift-gtk/statusicon.py:283
 msgid "Autostart"
 msgstr ""
 
-#: ../src/redshift-gtk/statusicon.py:289 ../src/redshift-gtk/statusicon.py:300
+#: ../src/redshift-gtk/statusicon.py:295 ../src/redshift-gtk/statusicon.py:306
 msgid "Info"
 msgstr ""
 
-#: ../src/redshift-gtk/statusicon.py:294
+#: ../src/redshift-gtk/statusicon.py:300
 msgid "Quit"
 msgstr ""
 
-#: ../src/redshift-gtk/statusicon.py:301
+#: ../src/redshift-gtk/statusicon.py:307
 msgid "Close"
 msgstr ""
 
-#: ../src/redshift-gtk/statusicon.py:466
+#: ../src/redshift-gtk/statusicon.py:472
 msgid "<b>Status:</b> {}"
 msgstr ""
 
-#: ../src/redshift-gtk/statusicon.py:470
+#: ../src/redshift-gtk/statusicon.py:476
 msgid "Color temperature"
 msgstr ""
 
-#: ../src/redshift-gtk/statusicon.py:474
+#: ../src/redshift-gtk/statusicon.py:480
 msgid "Period"
 msgstr ""
 
-#: ../src/redshift-gtk/statusicon.py:478
+#: ../src/redshift-gtk/statusicon.py:484
 msgid "Location"
 msgstr ""

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -20,6 +20,7 @@ redshift_SOURCES = \
 	gamma-dummy.c gamma-dummy.h
 
 EXTRA_redshift_SOURCES = \
+	gamma-dbus.c gamma-dbus.h \
 	gamma-drm.c gamma-drm.h \
 	gamma-randr.c gamma-randr.h \
 	gamma-vidmode.c gamma-vidmode.h \
@@ -30,6 +31,13 @@ EXTRA_redshift_SOURCES = \
 AM_CFLAGS =
 redshift_LDADD = @LIBINTL@
 EXTRA_DIST =
+
+if ENABLE_DBUS
+redshift_SOURCES += gamma-dbus.c gamma-dbus.h
+AM_CFLAGS += $(DBUS_CFLAGS)
+redshift_LDADD += \
+	$(DBUS_LIBS) $(DBUS_CFLAGS)
+endif
 
 if ENABLE_DRM
 redshift_SOURCES += gamma-drm.c gamma-drm.h

--- a/src/gamma-dbus.c
+++ b/src/gamma-dbus.c
@@ -1,0 +1,145 @@
+/* gamma-dbus.c -- DBus gamma adjustment
+   This file is part of Redshift.
+
+   Redshift is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   Redshift is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with Redshift.  If not, see <http://www.gnu.org/licenses/>.
+
+   Copyright (c) 2016 Michael Farrell <micolous+git@gmail.com>
+*/
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#ifdef ENABLE_NLS
+# include <libintl.h>
+# define _(s) gettext(s)
+#else
+# define _(s) s
+#endif
+
+#include "redshift.h"
+#include "gamma-dbus.h"
+
+
+int
+gamma_dbus_init(dbus_state_t *state)
+{
+	state->conn = NULL;
+	state->use_session_bus = 0;
+	state->serial = 0;
+	return 0;
+}
+
+int
+gamma_dbus_start(dbus_state_t *state)
+{
+	DBusError err;
+	int ret;
+
+	dbus_error_init(&err);
+
+	// Connect to the dbus.
+	state->conn = dbus_bus_get(state->use_session_bus ? DBUS_BUS_SESSION : DBUS_BUS_SYSTEM, &err);
+	if (dbus_error_is_set(&err)) {
+		fprintf(stderr, _("DBus connection error (%s)\n"), err.message);
+		dbus_error_free(&err);
+	}
+	
+	if (state->conn == NULL) {
+		return -1;
+	}
+	
+	// Register our name on the bus
+	ret = dbus_bus_request_name(state->conn, GAMMA_DBUS_SOURCE_NAME, DBUS_NAME_FLAG_REPLACE_EXISTING, &err);
+	if (dbus_error_is_set(&err)) {
+		fprintf(stderr, _("DBus name error (%s)\n"), err.message);
+		dbus_error_free(&err);
+	}
+
+	if (ret != DBUS_REQUEST_NAME_REPLY_PRIMARY_OWNER) {
+		return -1;
+	}	
+
+	return 0;
+}
+
+void
+gamma_dbus_restore(dbus_state_t *state)
+{
+}
+
+void
+gamma_dbus_free(dbus_state_t *state)
+{
+}
+
+void
+gamma_dbus_print_help(FILE *f)
+{
+	fputs(_("Select where to send signals to dbus.\n"), f);
+	fputs("\n", f);
+
+	/* TRANSLATORS: DBUS help output
+	   left column must not be translated */
+	fputs(_("  session=1\tSend messages to the session instead of system bus\n"), f);
+	fputs("\n", f);
+}
+
+int
+gamma_dbus_set_option(dbus_state_t *state, const char *key, const char *value)
+{
+	if (strcasecmp(key, "session") == 0) {
+		state->use_session_bus = atoi(value);
+		if (state->use_session_bus < 0 || state->use_session_bus > 1) {
+			fprintf(stderr, _("session must be either 0 (use system bus) or 1 (use session bus)\n"));
+			return -1;
+		}
+	} else {
+		fprintf(stderr, _("Unknown method parameter: `%s'.\n"), key);
+		return -1;
+	}
+
+	return 0;
+}
+
+int
+gamma_dbus_set_temperature(dbus_state_t *state, const color_setting_t *setting)
+{
+	DBusMessage* msg;
+	DBusMessageIter args;
+
+	// Create a signal
+	msg = dbus_message_new_signal(GAMMA_DBUS_OBJECT_PATH, GAMMA_DBUS_INTERFACE_NAME, GAMMA_DBUS_SIGNAL_NAME);
+	if (msg == NULL) {
+		fprintf(stderr, _("DBus message is null\n"));
+		return -1;
+	}
+
+	// Add argument
+	dbus_message_iter_init_append(msg, &args);
+	if (!dbus_message_iter_append_basic(&args, DBUS_TYPE_INT16, &(setting->temperature))) {
+		fprintf(stderr, _("Out of memory!\n"));
+		return -1;
+	}
+
+	// Send the message
+	if (!dbus_connection_send(state->conn, msg, &(state->serial))) {
+		fprintf(stderr, _("Failed to send DBus message\n"));
+		return -1;
+	}
+
+	dbus_connection_flush(state->conn);
+	dbus_message_unref(msg);
+	return 0;
+}

--- a/src/gamma-dbus.h
+++ b/src/gamma-dbus.h
@@ -1,0 +1,49 @@
+/* gamma-dbus.h -- DBus gamma adjustment header
+   This file is part of Redshift.
+
+   Redshift is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   Redshift is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with Redshift.  If not, see <http://www.gnu.org/licenses/>.
+
+   Copyright (c) 2016 Michael Farrell <micolous+git@gmail.com>
+*/
+
+#ifndef REDSHIFT_GAMMA_DBUS_H
+#define REDSHIFT_GAMMA_DBUS_H
+
+#include <dbus/dbus.h>
+#include "redshift.h"
+
+#define GAMMA_DBUS_SOURCE_NAME "dk.jonls.redshift.dbus"
+#define GAMMA_DBUS_OBJECT_PATH "/dk/jonls/Redshift"
+#define GAMMA_DBUS_INTERFACE_NAME "dk.jonls.Redshift"
+#define GAMMA_DBUS_SIGNAL_NAME "Temperature"
+
+typedef struct {
+	DBusConnection* conn;
+	int use_session_bus;
+	dbus_uint32_t serial;
+} dbus_state_t;
+
+int gamma_dbus_init(dbus_state_t *state);
+int gamma_dbus_start(dbus_state_t *state);
+void gamma_dbus_free(dbus_state_t *state);
+
+void gamma_dbus_print_help(FILE *f);
+int gamma_dbus_set_option(dbus_state_t *state, const char *key, const char *value);
+
+void gamma_dbus_restore(dbus_state_t *state);
+int gamma_dbus_set_temperature(dbus_state_t *state,
+				const color_setting_t *setting);
+
+
+#endif /* ! REDSHIFT_GAMMA_DBUS_H */

--- a/src/redshift.c
+++ b/src/redshift.c
@@ -58,6 +58,10 @@
 
 #include "gamma-dummy.h"
 
+#ifdef ENABLE_DBUS
+# include "gamma-dbus.h"
+#endif
+
 #ifdef ENABLE_DRM
 # include "gamma-drm.h"
 #endif
@@ -98,6 +102,9 @@
 
 /* Union of state data for gamma adjustment methods */
 typedef union {
+#ifdef ENABLE_DBUS
+	dbus_state_t dbus;
+#endif
 #ifdef ENABLE_DRM
 	drm_state_t drm;
 #endif
@@ -176,6 +183,19 @@ static const gamma_method_t gamma_methods[] = {
 		(gamma_method_set_option_func *)w32gdi_set_option,
 		(gamma_method_restore_func *)w32gdi_restore,
 		(gamma_method_set_temperature_func *)w32gdi_set_temperature
+	},
+#endif
+#ifdef ENABLE_DBUS
+	// do this late, so we don't conflict with other methods
+	{
+		"dbus", 0,
+		(gamma_method_init_func *)gamma_dbus_init,
+		(gamma_method_start_func *)gamma_dbus_start,
+		(gamma_method_free_func *)gamma_dbus_free,
+		(gamma_method_print_help_func *)gamma_dbus_print_help,
+		(gamma_method_set_option_func *)gamma_dbus_set_option,
+		(gamma_method_restore_func *)gamma_dbus_restore,
+		(gamma_method_set_temperature_func *)gamma_dbus_set_temperature
 	},
 #endif
 	{


### PR DESCRIPTION
This pull request implements a new gamma driver for Redshift which supports DBus signal output.

This allows you to use Redshift's day/night calculations in other applications, for example, networked lighting control systems.

This is not a full DBus control implementation like #54, but rather something extremely basic to emit signals.  For example, the object does not even implement introspection.  It only emits signals and doesn't allow control of any kind.

The signals look like this when emitted on DBus:

``` console
$ dbus-monitor --system "type='signal',sender='dk.jonls.redshift.dbus',interface='dk.jonls.Redshift'"
signal sender=org.freedesktop.DBus -> dest=:1.3994 serial=2 path=/org/freedesktop/DBus; interface=org.freedesktop.DBus; member=NameAcquired
   string ":1.3994"
signal sender=:1.3742 -> dest=(null destination) serial=5994 path=/dk/jonls/Redshift; interface=dk.jonls.Redshift; member=Temperature
   int16 3500
signal sender=:1.3742 -> dest=(null destination) serial=5995 path=/dk/jonls/Redshift; interface=dk.jonls.Redshift; member=Temperature
   int16 3500
```

This can be used with a program which connects to DBus, listens for the signal, and then the message can be used appropriately.  This can also be used on embedded systems without Xorg.

Documentation for use is included with this pull request.
