### PR TITLE
Fix a typo in man page and French translation

### DIFF
--- a/po/fr.po
+++ b/po/fr.po
@@ -190,7 +190,7 @@ msgstr ""
 "  -p \t \t Mode d'impression (Impression des paramètres et fermeture)\n"
 "  -x \t \t Mode de réinitialisation (Supprimer les réglages de l'écran)\n"
 "  -r \t \t Désactiver les transitions de température\n"
-"  -t JOUR/NUIT \t Température des couleurs à appliquer le jour / la nuit\n"
+"  -t JOUR:NUIT \t Température des couleurs à appliquer le jour / la nuit\n"
 
 #. TRANSLATORS: help output 5
 #: ../src/redshift.c:492

--- a/redshift.1
+++ b/redshift.1
@@ -17,7 +17,7 @@ twilight and early morning, the color temperature transitions smoothly
 from night to daytime temperature to allow your eyes to slowly
 adapt over a period of about an hour. At night the color temperature
 should be set to match the lamps in your room. This is typically a low
-temperature at around 3000K\-4000K (default is 3700K). During the day,
+temperature at around 3000K\-4000K (default is 3500K). During the day,
 the color temperature should match the light from outside, typically
 around 5500K\-6500K (default is 5500K). The light has a higher
 temperature on an overcast day.
@@ -80,7 +80,7 @@ more red light.
 
 Default temperature values:
 .IP
-Daytime: 5500K, night: 3700K
+Daytime: 5500K, night: 3500K
 .SH CONFIGURATION FILE
 A configuration file with the name `redshift.conf' can optionally be
 placed in `~/.config/'. The file has standard INI format. General


### PR DESCRIPTION
The man page had the old night temperature (3700K); the French translation had a `/` in the `-t` usage, instead of `:`.