### PR TITLE
freebsd: alloca.h is not available on FreeBSD

### DIFF
--- a/src/gamma-drm.c
+++ b/src/gamma-drm.c
@@ -21,7 +21,11 @@
 #include <stdlib.h>
 #include <stdint.h>
 #include <string.h>
-#include <alloca.h>
+
+#ifndef __FreeBSD__
+# include <alloca.h>
+#endif
+
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>


### PR DESCRIPTION
Here is some info about alloca(3) on FreeBSD

    LIBRARY
         Standard C Library (libc, -lc)

    SYNOPSIS
         #include <stdlib.h>

         void *
         alloca(size_t size);