### PR TITLE
Fixed the screenshot URL.

### DIFF
--- a/data/appdata/redshift-gtk.appdata.xml.in
+++ b/data/appdata/redshift-gtk.appdata.xml.in
@@ -11,7 +11,7 @@
  </description>
  <screenshots>
    <screenshot type="default">
-     <image>http://jonls.dk/wp-content/uploads/screenshot1.png</image>
+     <image>http://jonls.dk/assets/screenshot1.png</image>
      <_caption>The Redshift information window overlaid with an example of the redness effect</_caption>
    </screenshot>
  </screenshots>


### PR DESCRIPTION
The current one was 404 not found. See https://software.opensuse.org/package/redshift-gtk which makes use of the link provided in the URL.