### PR TITLE
contrib: Add launchd file for macOS

### DIFF
--- a/contrib/macos/launchd/dk.jonls.redshift.plist
+++ b/contrib/macos/launchd/dk.jonls.redshift.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Label</key>
+	<string>dk.jonls.redshift</string>
+
+	<key>ProgramArguments</key>
+	<array>
+		<string>/usr/local/bin/redshift</string>
+	</array>
+
+	<key>Nice</key>
+	<integer>20</integer>
+
+	<key>RunAtLoad</key>
+	<true/>
+
+	<key>KeepAlive</key>
+	<true/>
+</dict>
+</plist>


### PR DESCRIPTION
Add launchd file for macOS in `contrib` directory as suggested in #398. 