### PR TITLE
redshift.c: Use 6500K and 4500K by default

### DIFF
--- a/src/redshift.c
+++ b/src/redshift.c
@@ -273,8 +273,8 @@ static const location_provider_t location_providers[] = {
 #define MAX_GAMMA  10.0
 
 /* Default values for parameters. */
-#define DEFAULT_DAY_TEMP    5500
-#define DEFAULT_NIGHT_TEMP  3500
+#define DEFAULT_DAY_TEMP    6500
+#define DEFAULT_NIGHT_TEMP  4500
 #define DEFAULT_BRIGHTNESS   1.0
 #define DEFAULT_GAMMA        1.0
 


### PR DESCRIPTION
As suggested in #262, a default value of 6500K for the daytime temperature would probably work better for most users. 4500K was suggested as the default nighttime temperature since it is less extreme. As always, the configuration file or command line can be used to select different temperatures.