### PR TITLE
add help message to redshift-gtk

### DIFF
--- a/src/redshift-gtk/redshift-gtk.in
+++ b/src/redshift-gtk/redshift-gtk.in
@@ -23,5 +23,8 @@ import sys
 sys.path.append('@pythondir@')
 
 if __name__ == '__main__':
+    if '-h' in sys.argv:
+        print('Please use the `redshift` program for help output.')
+
     from redshift_gtk.statusicon import run
     run()


### PR DESCRIPTION
Currently running `redshift-gtk` with any args that normally produce help/info output with the `redshift` program, such as `redshift-gtk -h`, exits silently with no output. This is due to how the child process is being attached and stdout processed.

This adds a helpful message to redirect users to the `redshift` program when running `redshift-gtk -h`.