### PR TITLE
x86 builds for windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,8 +109,8 @@ Latest builds from master branch
 --------------------------------
 
 - [Ubuntu PPA](https://launchpad.net/~dobey/+archive/ubuntu/redshift-daily/+packages) (`sudo add-apt-repository ppa:dobey/redshift-daily`)
-- [Windows x86_64](https://ci.appveyor.com/api/projects/jonls/redshift/artifacts/redshift-windows-x86_64.zip?branch=master)
-- [Windows x86](https://ci.appveyor.com/api/projects/jonls/redshift/artifacts/redshift-windows-i686.zip?branch=master)
+- [Windows x86_64](https://ci.appveyor.com/api/projects/jonls/redshift/artifacts/redshift-windows-x86_64.zip?branch=master&job=Environment%3A+arch%3Dx86_64)
+- [Windows x86](https://ci.appveyor.com/api/projects/jonls/redshift/artifacts/redshift-windows-i686.zip?branch=master&job=Environment%3A+arch%3Di686)
 
 Building from source
 --------------------

--- a/README.md
+++ b/README.md
@@ -109,8 +109,8 @@ Latest builds from master branch
 --------------------------------
 
 - [Ubuntu PPA](https://launchpad.net/~dobey/+archive/ubuntu/redshift-daily/+packages) (`sudo add-apt-repository ppa:dobey/redshift-daily`)
-- [Windows x86_64](https://ci.appveyor.com/api/projects/jonls/redshift/artifacts/redshift-windows-x86_64.zip?branch=master&job=Environment%3A+arch%3Dx86_64)
-- [Windows x86](https://ci.appveyor.com/api/projects/jonls/redshift/artifacts/redshift-windows-i686.zip?branch=master&job=Environment%3A+arch%3Di686)
+- [Windows x86_64](https://ci.appveyor.com/api/projects/jonls/redshift/artifacts/redshift-windows-x86_64.zip?branch=master&job=Environment%3A+arch%3Dx86_64&pr=false)
+- [Windows x86](https://ci.appveyor.com/api/projects/jonls/redshift/artifacts/redshift-windows-i686.zip?branch=master&job=Environment%3A+arch%3Di686&pr=false)
 
 Building from source
 --------------------

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,21 +4,23 @@ image:
 environment:
   matrix:
     - arch: x86_64
-      HOST_ARCH_ARG: --host=x86_64-w64-mingw32
-      ADD_PATH_CMD: C:\msys64\usr\bin;C:\mingw-w64\x86_64-6.3.0-posix-seh-rt_v5-rev1\mingw64\bin
-      MSYSTEM: MINGW64
     - arch: i686
-      HOST_ARCH_ARG: --host=i686-w64-mingw32
-      ADD_PATH_CMD: C:\msys64\usr\bin;C:\mingw-w64\i686-5.3.0-posix-dwarf-rt_v4-rev0\mingw32\bin
-      MSYSTEM: MINGW32
 
 build:
   verbosity: detailed
 
 build_script:
+- if [%arch%]==[x86_64] (
+      SET "ADD_PATH_CMD=C:\mingw-w64\i686-6.3.0-posix-dwarf-rt_v5-rev1\mingw32\bin" &&
+      SET "MSYSTEM=MINGW64"
+    )
+- if [%arch%]==[i686] (
+      SET "ADD_PATH_CMD=C:\msys64\usr\bin;C:\mingw-w64\i686-6.3.0-posix-dwarf-rt_v5-rev1\mingw32\bin" &&
+      SET "MSYSTEM=MINGW32"
+    )
 - set PATH=%ADD_PATH_CMD%;%PATH%
 - bash -lc "cd $APPVEYOR_BUILD_FOLDER && ./bootstrap"
-- bash -lc "cd $APPVEYOR_BUILD_FOLDER && ./configure --enable-static --disable-shared --disable-drm --disable-randr --disable-vidmode --enable-wingdi --disable-quartz --disable-geoclue --disable-geoclue2 --disable-corelocation --disable-gui --disable-ubuntu --disable-nls $HOST_ARCH_ARG"
+- bash -lc "cd $APPVEYOR_BUILD_FOLDER && ./configure --enable-static --disable-shared --disable-drm --disable-randr --disable-vidmode --enable-wingdi --disable-quartz --disable-geoclue --disable-geoclue2 --disable-corelocation --disable-gui --disable-ubuntu --disable-nls --host=$arch-w64-mingw32"
 - bash -lc "cd $APPVEYOR_BUILD_FOLDER && make"
 
 after_build:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,19 +2,21 @@ image:
 - Visual Studio 2015
 
 environment:
-  MSYS_ARCH: x86_64
+  matrix:
+    - HOST_ARCH_ARG: --host=x86_64-w64-mingw32
+      ADD_PATH_CMD: C:\msys64\usr\bin;C:\mingw-w64\x86_64-6.3.0-posix-seh-rt_v5-rev1\mingw64\bin
+      MSYSTEM: MINGW64
+    - HOST_ARCH_ARG: --host=i686-w64-mingw32
+      ADD_PATH_CMD: C:\msys64\usr\bin;C:\mingw-w64\i686-5.3.0-posix-dwarf-rt_v4-rev0\mingw32\bin
+      MSYSTEM: MINGW32
 
 build:
   verbosity: detailed
 
 build_script:
-- echo %PATH%
-- set PATH=C:\msys64\usr\bin;C:\mingw-w64\x86_64-6.3.0-posix-seh-rt_v5-rev1\mingw64\bin;%PATH%
-- set CC=gcc
-- set MSYSTEM=MINGW64
-- bash -lc "pwd"
+- set PATH=%ADD_PATH_CMD%;%PATH%
 - bash -lc "cd $APPVEYOR_BUILD_FOLDER && ./bootstrap"
-- bash -lc "cd $APPVEYOR_BUILD_FOLDER && ./configure --enable-static --disable-shared --disable-drm --disable-randr --disable-vidmode --enable-wingdi --disable-quartz --disable-geoclue --disable-geoclue2 --disable-corelocation --disable-gui --disable-ubuntu --disable-nls --host=x86_64-w64-mingw32"
+- bash -lc "cd $APPVEYOR_BUILD_FOLDER && ./configure --enable-static --disable-shared --disable-drm --disable-randr --disable-vidmode --enable-wingdi --disable-quartz --disable-geoclue --disable-geoclue2 --disable-corelocation --disable-gui --disable-ubuntu --disable-nls $HOST_ARCH_ARG"
 - bash -lc "cd $APPVEYOR_BUILD_FOLDER && make"
 
 after_build:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,10 +3,12 @@ image:
 
 environment:
   matrix:
-    - HOST_ARCH_ARG: --host=x86_64-w64-mingw32
+    - arch: x86_64
+      HOST_ARCH_ARG: --host=x86_64-w64-mingw32
       ADD_PATH_CMD: C:\msys64\usr\bin;C:\mingw-w64\x86_64-6.3.0-posix-seh-rt_v5-rev1\mingw64\bin
       MSYSTEM: MINGW64
-    - HOST_ARCH_ARG: --host=i686-w64-mingw32
+    - arch: i686
+      HOST_ARCH_ARG: --host=i686-w64-mingw32
       ADD_PATH_CMD: C:\msys64\usr\bin;C:\mingw-w64\i686-5.3.0-posix-dwarf-rt_v4-rev0\mingw32\bin
       MSYSTEM: MINGW32
 
@@ -21,6 +23,6 @@ build_script:
 
 after_build:
 - cmd: >-
-    7z a redshift.zip ./src/redshift.exe COPYING NEWS README.md
+    7z a redshift-windows-%arch%.zip ./src/redshift.exe COPYING NEWS README.md
 
-    appveyor PushArtifact redshift.zip
+    appveyor PushArtifact redshift-windows-%arch%.zip

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,14 +11,12 @@ build:
 
 build_script:
 - if [%arch%]==[x86_64] (
-      SET "ADD_PATH_CMD=C:\msys64\usr\bin;C:\mingw-w64\x86_64-6.3.0-posix-seh-rt_v5-rev1\mingw64\bin" &&
-      SET "MSYSTEM=MINGW64"
-    )
+    SET "ADD_PATH_CMD=C:\mingw-w64\x86_64-6.3.0-posix-seh-rt_v5-rev1\mingw64\bin"
+  )
 - if [%arch%]==[i686] (
-      SET "ADD_PATH_CMD=C:\msys64\usr\bin;C:\mingw-w64\i686-6.3.0-posix-dwarf-rt_v5-rev1\mingw32\bin" &&
-      SET "MSYSTEM=MINGW32"
-    )
-- set PATH=%ADD_PATH_CMD%;%PATH%
+    SET "ADD_PATH_CMD=C:\mingw-w64\i686-6.3.0-posix-dwarf-rt_v5-rev1\mingw32\bin"
+  )
+- set PATH=C:\msys64\usr\bin;%ADD_PATH_CMD%;%PATH%
 - bash -lc "cd $APPVEYOR_BUILD_FOLDER && ./bootstrap"
 - bash -lc "cd $APPVEYOR_BUILD_FOLDER && ./configure --enable-static --disable-shared --disable-drm --disable-randr --disable-vidmode --enable-wingdi --disable-quartz --disable-geoclue --disable-geoclue2 --disable-corelocation --disable-gui --disable-ubuntu --disable-nls --host=$arch-w64-mingw32"
 - bash -lc "cd $APPVEYOR_BUILD_FOLDER && make"


### PR DESCRIPTION
This PR allows i686 build on appveyor for Windows.

fix #342

