### PR TITLE
Appveyor: Run distcheck and improve zip package

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,12 +17,15 @@ build_script:
     SET "ADD_PATH_CMD=C:\mingw-w64\i686-6.3.0-posix-dwarf-rt_v5-rev1\mingw32\bin"
   )
 - set PATH=C:\msys64\usr\bin;%ADD_PATH_CMD%;%PATH%
+- set CONFIGURE_FLAGS=--disable-drm --disable-randr --disable-vidmode --enable-wingdi --disable-quartz --disable-geoclue --disable-geoclue2 --disable-corelocation --disable-gui --disable-ubuntu --disable-nls --host=%arch%-w64-mingw32
+- bash -lc "mkdir $APPVEYOR_BUILD_FOLDER/root"
 - bash -lc "cd $APPVEYOR_BUILD_FOLDER && ./bootstrap"
-- bash -lc "cd $APPVEYOR_BUILD_FOLDER && ./configure --enable-static --disable-shared --disable-drm --disable-randr --disable-vidmode --enable-wingdi --disable-quartz --disable-geoclue --disable-geoclue2 --disable-corelocation --disable-gui --disable-ubuntu --disable-nls --host=$arch-w64-mingw32"
-- bash -lc "cd $APPVEYOR_BUILD_FOLDER && make"
+- bash -lc "cd $APPVEYOR_BUILD_FOLDER && ./configure --prefix=\"$APPVEYOR_BUILD_FOLDER/root\" $CONFIGURE_FLAGS"
+- bash -lc "cd $APPVEYOR_BUILD_FOLDER && make distcheck DISTCHECK_CONFIGURE_FLAGS=\"$CONFIGURE_FLAGS\""
+- bash -lc "cd $APPVEYOR_BUILD_FOLDER && make install"
 
 after_build:
 - cmd: >-
-    7z a redshift-windows-%arch%.zip ./src/redshift.exe COPYING NEWS README.md
+    7z a redshift-windows-%arch%.zip "%APPVEYOR_BUILD_FOLDER%/root/bin/redshift.exe" COPYING NEWS README.md
 
     appveyor PushArtifact redshift-windows-%arch%.zip

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,7 +25,16 @@ build_script:
 - bash -lc "cd $APPVEYOR_BUILD_FOLDER && make install"
 
 after_build:
-- cmd: >-
-    7z a redshift-windows-%arch%.zip "%APPVEYOR_BUILD_FOLDER%/root/bin/redshift.exe" COPYING NEWS README.md
+- ps: |
+    $ZIP_NAME = "redshift-windows-$env:arch"
+    $ZIP_FILE = "redshift-windows-$env:arch.zip"
 
-    appveyor PushArtifact redshift-windows-%arch%.zip
+    md $ZIP_NAME
+    Copy-Item -Path $env:APPVEYOR_BUILD_FOLDER\root\bin\redshift.exe -Destination $ZIP_NAME
+    Copy-Item -Path README.md -Destination $ZIP_NAME/README.txt
+    Copy-Item -Path NEWS.md -Destination $ZIP_NAME/NEWS.txt
+    Copy-Item -Path COPYING -Destination $ZIP_NAME/COPYING.txt
+    Copy-Item -Path redshift.conf.sample -Destination $ZIP_NAME
+    7z a $ZIP_FILE $ZIP_NAME/
+
+- ps: Push-AppveyorArtifact $ZIP_FILE


### PR DESCRIPTION
This ensures that all files required for Windows build are correctly bundled in the source archive produced by autotools.

In the zip package, various text files are renamed with .txt extension to make it easier to open these files on Windows. Also bundles the sample configuration file.