### PR TITLE
GeoClue: better error message when access is denied

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,9 @@ FAQ
 
 **How do I install Redshift?**
 
-Use the packages provided by your distribution, e.g. for Ubuntu: `apt-get install redshift` or `apt-get install redshift-gtk`. For developers, please see _Building from source_ and _Latest builds from master branch_ below.
+Use the packages provided by your distribution, e.g. for Ubuntu:
+`apt-get install redshift` or `apt-get install redshift-gtk`. For developers,
+please see _Building from source_ and _Latest builds from master branch_ below.
 
 **How do I setup a configuration file?**
 
@@ -47,6 +49,18 @@ There are multiple web sites that provide coordinates for map locations, for
 example clicking anywhere on Google Maps will bring up a box with the
 coordinates. Remember that longitudes in the western hemisphere (e.g. the
 Americas) must be provided to Redshift as negative numbers.
+
+**Why does GeoClue fail with access denied error?**
+
+It is possible that the location services have been disabled completely. The
+check for this case varies by desktop environment. For example, in GNOME the
+location services can be toggled in Settings > Privacy > Location Services.
+
+If this is not the case, it is possible that Redshift has been improperly
+installed or not been given the required permissions to obtain location
+updates from a system administrator. See
+https://github.com/jonls/redshift/issues/318 for further discussion on this
+issue.
 
 **Why doesn't Redshift work on my Chromebook/Raspberry Pi?**
 

--- a/src/location-geoclue2.c
+++ b/src/location-geoclue2.c
@@ -68,8 +68,8 @@ geoclue_client_signal_cb(GDBusProxy *client, gchar *sender_name,
 
 	/* Obtain location */
 	GError *error = NULL;
-	GDBusProxy *location = g_dbus_proxy_new_for_bus_sync(
-		G_BUS_TYPE_SYSTEM,
+	GDBusProxy *location = g_dbus_proxy_new_sync(
+		g_dbus_proxy_get_connection(client),
 		G_DBUS_PROXY_FLAGS_NONE,
 		NULL,
 		"org.freedesktop.GeoClue2",
@@ -111,8 +111,8 @@ on_name_appeared(GDBusConnection *conn, const gchar *name,
 
 	/* Obtain GeoClue Manager */
 	GError *error = NULL;
-	GDBusProxy *geoclue_manager = g_dbus_proxy_new_for_bus_sync(
-		G_BUS_TYPE_SYSTEM,
+	GDBusProxy *geoclue_manager = g_dbus_proxy_new_sync(
+		conn,
 		G_DBUS_PROXY_FLAGS_NONE,
 		NULL,
 		"org.freedesktop.GeoClue2",
@@ -149,8 +149,8 @@ on_name_appeared(GDBusConnection *conn, const gchar *name,
 
 	/* Obtain GeoClue client */
 	error = NULL;
-	GDBusProxy *geoclue_client = g_dbus_proxy_new_for_bus_sync(
-		G_BUS_TYPE_SYSTEM,
+	GDBusProxy *geoclue_client = g_dbus_proxy_new_sync(
+		conn,
 		G_DBUS_PROXY_FLAGS_NONE,
 		NULL,
 		"org.freedesktop.GeoClue2",


### PR DESCRIPTION
This adds a better explanation when access to the location from GeoClue is denied. This is similar to #480 and is based on the discussion in #289.