### PR TITLE
Preserve gamma ramps by default

### DIFF
--- a/src/gamma-quartz.c
+++ b/src/gamma-quartz.c
@@ -40,7 +40,7 @@
 int
 quartz_init(quartz_state_t *state)
 {
-	state->preserve = 0;
+	state->preserve = 1;
 	state->displays = NULL;
 
 	return 0;

--- a/src/gamma-randr.c
+++ b/src/gamma-randr.c
@@ -53,7 +53,7 @@ randr_init(randr_state_t *state)
 	state->crtc_count = 0;
 	state->crtcs = NULL;
 
-	state->preserve = 0;
+	state->preserve = 1;
 
 	xcb_generic_error_t *error;
 

--- a/src/gamma-vidmode.c
+++ b/src/gamma-vidmode.c
@@ -43,7 +43,7 @@ vidmode_init(vidmode_state_t *state)
 	state->screen_num = -1;
 	state->saved_ramps = NULL;
 
-	state->preserve = 0;
+	state->preserve = 1;
 
 	/* Open display */
 	state->display = XOpenDisplay(NULL);

--- a/src/gamma-w32gdi.c
+++ b/src/gamma-w32gdi.c
@@ -43,7 +43,7 @@ int
 w32gdi_init(w32gdi_state_t *state)
 {
 	state->saved_ramps = NULL;
-	state->preserve = 0;
+	state->preserve = 1;
 
 	return 0;
 }


### PR DESCRIPTION
The gamma ramp adjustment methods (quartz, randr, vidmode and w32gdi) have supported an option to preserve the gamma ramps on startup and apply the redness effect on top of those existing gamma ramps. Previously this option was not enabled by default. Since no issues have been reported so far with this option it is now enabled by default.