### PR TITLE
Fix #513: "preserve" made all modes but CONTINUAL unable to decrease redness

### DIFF
--- a/src/gamma-drm.c
+++ b/src/gamma-drm.c
@@ -222,6 +222,12 @@ drm_print_help(FILE *f)
 }
 
 int
+drm_set_mode(drm_state_t *state, const program_mode_t mode)
+{
+	return 0;
+}
+
+int
 drm_set_option(drm_state_t *state, const char *key, const char *value)
 {
 	if (strcasecmp(key, "card") == 0) {

--- a/src/gamma-drm.h
+++ b/src/gamma-drm.h
@@ -51,6 +51,8 @@ int drm_start(drm_state_t *state);
 void drm_free(drm_state_t *state);
 
 void drm_print_help(FILE *f);
+int drm_set_mode(drm_state_t *state,
+			const program_mode_t mode);
 int drm_set_option(drm_state_t *state, const char *key, const char *value);
 
 void drm_restore(drm_state_t *state);

--- a/src/gamma-dummy.c
+++ b/src/gamma-dummy.c
@@ -61,6 +61,12 @@ gamma_dummy_print_help(FILE *f)
 }
 
 int
+gamma_dummy_set_mode(void *state, const program_mode_t mode)
+{
+	return 0;
+}
+
+int
 gamma_dummy_set_option(void *state, const char *key, const char *value)
 {
 	fprintf(stderr, _("Unknown method parameter: `%s'.\n"), key);

--- a/src/gamma-dummy.h
+++ b/src/gamma-dummy.h
@@ -28,6 +28,8 @@ int gamma_dummy_start(void *state);
 void gamma_dummy_free(void *state);
 
 void gamma_dummy_print_help(FILE *f);
+int gamma_dummy_set_mode(void *state,
+			const program_mode_t mode);
 int gamma_dummy_set_option(void *state, const char *key, const char *value);
 
 void gamma_dummy_restore(void *state);

--- a/src/gamma-quartz.c
+++ b/src/gamma-quartz.c
@@ -164,6 +164,13 @@ quartz_print_help(FILE *f)
 }
 
 int
+quartz_set_mode(quartz_state_t *state, const program_mode_t mode)
+{
+	state->preserve = PROGRAM_MODE_CONTINUAL == mode;
+	return 0;
+}
+
+int
 quartz_set_option(quartz_state_t *state, const char *key, const char *value)
 {
 	if (strcasecmp(key, "preserve") == 0) {

--- a/src/gamma-quartz.h
+++ b/src/gamma-quartz.h
@@ -45,6 +45,8 @@ int quartz_start(quartz_state_t *state);
 void quartz_free(quartz_state_t *state);
 
 void quartz_print_help(FILE *f);
+int quartz_set_mode(quartz_state_t *state,
+			const program_mode_t mode);
 int quartz_set_option(quartz_state_t *state, const char *key,
 		      const char *value);
 

--- a/src/gamma-randr.c
+++ b/src/gamma-randr.c
@@ -288,6 +288,13 @@ randr_print_help(FILE *f)
 }
 
 int
+randr_set_mode(randr_state_t *state, const program_mode_t mode)
+{
+	state->preserve = PROGRAM_MODE_CONTINUAL == mode;
+	return 0;
+}
+
+int
 randr_set_option(randr_state_t *state, const char *key, const char *value)
 {
 	if (strcasecmp(key, "screen") == 0) {

--- a/src/gamma-randr.h
+++ b/src/gamma-randr.h
@@ -53,6 +53,8 @@ int randr_start(randr_state_t *state);
 void randr_free(randr_state_t *state);
 
 void randr_print_help(FILE *f);
+int randr_set_mode(randr_state_t *state,
+			const program_mode_t mode);
 int randr_set_option(randr_state_t *state, const char *key, const char *value);
 
 void randr_restore(randr_state_t *state);

--- a/src/gamma-vidmode.c
+++ b/src/gamma-vidmode.c
@@ -139,6 +139,13 @@ vidmode_print_help(FILE *f)
 }
 
 int
+vidmode_set_mode(vidmode_state_t *state, const program_mode_t mode)
+{
+	state->preserve = PROGRAM_MODE_CONTINUAL == mode;
+	return 0;
+}
+
+int
 vidmode_set_option(vidmode_state_t *state, const char *key, const char *value)
 {
 	if (strcasecmp(key, "screen") == 0) {

--- a/src/gamma-vidmode.h
+++ b/src/gamma-vidmode.h
@@ -41,6 +41,8 @@ int vidmode_start(vidmode_state_t *state);
 void vidmode_free(vidmode_state_t *state);
 
 void vidmode_print_help(FILE *f);
+int vidmode_set_mode(vidmode_state_t *state,
+			const program_mode_t mode);
 int vidmode_set_option(vidmode_state_t *state, const char *key,
 		       const char *value);
 

--- a/src/gamma-w32gdi.c
+++ b/src/gamma-w32gdi.c
@@ -113,6 +113,13 @@ w32gdi_print_help(FILE *f)
 }
 
 int
+w32gdi_set_mode(w32gdi_state_t *state, const program_mode_t mode)
+{
+	state->preserve = PROGRAM_MODE_CONTINUAL == mode;
+	return 0;
+}
+
+int
 w32gdi_set_option(w32gdi_state_t *state, const char *key, const char *value)
 {
 	if (strcasecmp(key, "preserve") == 0) {

--- a/src/gamma-w32gdi.h
+++ b/src/gamma-w32gdi.h
@@ -37,6 +37,8 @@ int w32gdi_start(w32gdi_state_t *state);
 void w32gdi_free(w32gdi_state_t *state);
 
 void w32gdi_print_help(FILE *f);
+int w32gdi_set_mode(w32gdi_state_t *state,
+			const program_mode_t mode);
 int w32gdi_set_option(w32gdi_state_t *state, const char *key,
 		      const char *value);
 

--- a/src/redshift.c
+++ b/src/redshift.c
@@ -136,6 +136,7 @@ static const gamma_method_t gamma_methods[] = {
 		(gamma_method_start_func *)drm_start,
 		(gamma_method_free_func *)drm_free,
 		(gamma_method_print_help_func *)drm_print_help,
+		(gamma_method_set_mode_func *)drm_set_mode,
 		(gamma_method_set_option_func *)drm_set_option,
 		(gamma_method_restore_func *)drm_restore,
 		(gamma_method_set_temperature_func *)drm_set_temperature
@@ -148,6 +149,7 @@ static const gamma_method_t gamma_methods[] = {
 		(gamma_method_start_func *)randr_start,
 		(gamma_method_free_func *)randr_free,
 		(gamma_method_print_help_func *)randr_print_help,
+		(gamma_method_set_mode_func *)randr_set_mode,
 		(gamma_method_set_option_func *)randr_set_option,
 		(gamma_method_restore_func *)randr_restore,
 		(gamma_method_set_temperature_func *)randr_set_temperature
@@ -160,6 +162,7 @@ static const gamma_method_t gamma_methods[] = {
 		(gamma_method_start_func *)vidmode_start,
 		(gamma_method_free_func *)vidmode_free,
 		(gamma_method_print_help_func *)vidmode_print_help,
+		(gamma_method_set_mode_func *)vidmode_set_mode,
 		(gamma_method_set_option_func *)vidmode_set_option,
 		(gamma_method_restore_func *)vidmode_restore,
 		(gamma_method_set_temperature_func *)vidmode_set_temperature
@@ -172,6 +175,7 @@ static const gamma_method_t gamma_methods[] = {
 		(gamma_method_start_func *)quartz_start,
 		(gamma_method_free_func *)quartz_free,
 		(gamma_method_print_help_func *)quartz_print_help,
+		(gamma_method_set_mode_func *)quartz_set_mode,
 		(gamma_method_set_option_func *)quartz_set_option,
 		(gamma_method_restore_func *)quartz_restore,
 		(gamma_method_set_temperature_func *)quartz_set_temperature
@@ -184,6 +188,7 @@ static const gamma_method_t gamma_methods[] = {
 		(gamma_method_start_func *)w32gdi_start,
 		(gamma_method_free_func *)w32gdi_free,
 		(gamma_method_print_help_func *)w32gdi_print_help,
+		(gamma_method_set_mode_func *)w32gdi_set_mode,
 		(gamma_method_set_option_func *)w32gdi_set_option,
 		(gamma_method_restore_func *)w32gdi_restore,
 		(gamma_method_set_temperature_func *)w32gdi_set_temperature
@@ -195,6 +200,7 @@ static const gamma_method_t gamma_methods[] = {
 		(gamma_method_start_func *)gamma_dummy_start,
 		(gamma_method_free_func *)gamma_dummy_free,
 		(gamma_method_print_help_func *)gamma_dummy_print_help,
+		(gamma_method_set_mode_func *)gamma_dummy_set_mode,
 		(gamma_method_set_option_func *)gamma_dummy_set_option,
 		(gamma_method_restore_func *)gamma_dummy_restore,
 		(gamma_method_set_temperature_func *)gamma_dummy_set_temperature
@@ -294,15 +300,6 @@ static const location_provider_t location_providers[] = {
 
 /* Length of fade in numbers of short sleep durations. */
 #define FADE_LENGTH  40
-
-/* Program modes. */
-typedef enum {
-	PROGRAM_MODE_CONTINUAL,
-	PROGRAM_MODE_ONE_SHOT,
-	PROGRAM_MODE_PRINT,
-	PROGRAM_MODE_RESET,
-	PROGRAM_MODE_MANUAL
-} program_mode_t;
 
 /* Transition scheme.
    The solar elevations at which the transition begins/ends,
@@ -1687,6 +1684,13 @@ main(int argc, char *argv[])
 				exit(EXIT_FAILURE);
 			}
 		}
+	}
+
+	r = method->set_mode(&state, mode);
+	if (r < 0) {
+		fprintf(stderr, _("Setting of mode failed for %s.\n"),
+					method->name);
+		return -1;
 	}
 
 	config_ini_free(&config_state);

--- a/src/redshift.h
+++ b/src/redshift.h
@@ -38,6 +38,15 @@ typedef enum {
 	PERIOD_TRANSITION
 } period_t;
 
+/* Program modes. */
+typedef enum {
+	PROGRAM_MODE_CONTINUAL,
+	PROGRAM_MODE_ONE_SHOT,
+	PROGRAM_MODE_PRINT,
+	PROGRAM_MODE_RESET,
+	PROGRAM_MODE_MANUAL
+} program_mode_t;
+
 /* Color setting */
 typedef struct {
 	int temperature;
@@ -51,6 +60,7 @@ typedef int gamma_method_init_func(void *state);
 typedef int gamma_method_start_func(void *state);
 typedef void gamma_method_free_func(void *state);
 typedef void gamma_method_print_help_func(FILE *f);
+typedef int gamma_method_set_mode_func(void *state, const program_mode_t mode);
 typedef int gamma_method_set_option_func(void *state, const char *key,
 					 const char *value);
 typedef void gamma_method_restore_func(void *state);
@@ -72,6 +82,8 @@ typedef struct {
 
 	/* Print help on options for this adjustment method. */
 	gamma_method_print_help_func *print_help;
+	/* Set program mode. Used to set state->preserve for many gamma modules. */
+	gamma_method_set_mode_func *set_mode;
 	/* Set an option key, value-pair */
 	gamma_method_set_option_func *set_option;
 
@@ -112,6 +124,5 @@ typedef struct {
 	location_provider_get_fd_func *get_fd;
 	location_provider_handle_func *handle;
 } location_provider_t;
-
 
 #endif /* ! REDSHIFT_REDSHIFT_H */


### PR DESCRIPTION
Addresses this issue: https://github.com/jonls/redshift/issues/513

It appears that in `gamma-*` modules where `state->preserve` is in use, it was always set to true, even for one-off, manual, etc. modes. This became a problem in `randr_set_temperature_for_crtc`, at least, where updates would try to make use of saved gamma ramps.

This revision makes the change of sending the mode to the `gamma-*` module after the mode and method are both determined. The `gamma-*` module then updates `state->preserve` if it exists for that module.