### PR TITLE
Add AppArmor profile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,7 @@ src/redshift-gtk/__pycache__/
 /data/appdata/redshift-gtk.appdata.xml
 /data/applications/redshift.desktop
 /data/applications/redshift-gtk.desktop
+/data/apparmor/usr.bin.redshift
 
 *.su
 *.gch

--- a/Makefile.am
+++ b/Makefile.am
@@ -39,6 +39,9 @@ SYSTEMD_USER_UNIT_IN_FILES = \
 APPDATA_IN_FILES = \
 	data/appdata/redshift-gtk.appdata.xml.in
 
+APPARMOR_IN_FILES = \
+	data/apparmor/usr.bin.redshift.in
+
 
 # Icons
 if ENABLE_GUI
@@ -103,6 +106,17 @@ appdata_DATA = $(APPDATA_IN_FILES:.xml.in=.xml)
 endif
 
 
+# AppArmor profile
+if ENABLE_APPARMOR
+apparmordir = @sysconfdir@/apparmor.d
+apparmor_DATA = $(APPARMOR_IN_FILES:.in=)
+
+$(apparmor_DATA): $(APPARMOR_IN_FILES) Makefile
+	$(AM_V_GEN)$(MKDIR_P) $(@D) && \
+		sed -e "s|\@bindir\@|$(bindir)|g" "$(srcdir)/$(@:=.in)" > $@
+endif
+
+
 
 EXTRA_DIST = \
 	$(EXTRA_ROOTDOC_FILES) \
@@ -111,12 +125,14 @@ EXTRA_DIST = \
 	$(_UBUNTU_MONO_LIGHT_FILES) \
 	$(DESKTOP_IN_FILES) \
 	$(SYSTEMD_USER_UNIT_IN_FILES) \
-	$(APPDATA_IN_FILES)
+	$(APPDATA_IN_FILES) \
+	$(APPARMOR_IN_FILES)
 
 CLEANFILES = \
 	$(desktop_DATA) \
 	$(systemduserunit_DATA) \
-	$(appdata_DATA)
+	$(appdata_DATA) \
+	$(apparmor_DATA)
 
 
 # Update PO translations

--- a/configure.ac
+++ b/configure.ac
@@ -331,6 +331,21 @@ AS_IF([test -n "$with_systemduserunitdir" -a "x$with_systemduserunitdir" != xno]
 AM_CONDITIONAL([ENABLE_SYSTEMD], [test "x$enable_systemd" != xno])
 
 
+# Check for AppArmor
+AC_MSG_CHECKING([whether to enable AppArmor profile])
+AC_ARG_ENABLE([apparmor], [AC_HELP_STRING([--enable-apparmor],
+	[enable AppArmor profile])],
+        [enable_apparmor=$enableval],[enable_apparmor=no])
+AS_IF([test "x$enable_apparmor" != xno], [
+        AC_MSG_RESULT([yes])
+	enable_apparmor=yes
+], [
+        AC_MSG_RESULT([no])
+	enable_apparmor=no
+])
+AM_CONDITIONAL([ENABLE_APPARMOR], [test "x$enable_apparmor" != xno])
+
+
 # Checks for header files.
 AC_CHECK_HEADERS([locale.h stdint.h stdlib.h string.h unistd.h signal.h])
 
@@ -373,4 +388,5 @@ echo "
     GUI:		${enable_gui}
     Ubuntu icons:	${enable_ubuntu}
     systemd units:	${enable_systemd} ${systemduserunitdir}
+    AppArmor profile:   ${enable_apparmor}
 "

--- a/data/apparmor/usr.bin.redshift.in
+++ b/data/apparmor/usr.bin.redshift.in
@@ -1,0 +1,42 @@
+# ------------------------------------------------------------------
+#
+#    Copyright (C) 2015 Cameron Norman <camerontnorman@gmail.com>
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# ------------------------------------------------------------------
+
+#include <tunables/global>
+@bindir@/redshift {
+  #include <abstractions/base>
+  #include <abstractions/nameservice>
+  #include <abstractions/dbus-strict>
+  #include <abstractions/X>
+
+  dbus send
+       bus=system
+       path=/org/freedesktop/GeoClue2/Client/[0-9]*,
+
+  dbus receive
+       bus=system
+       path=/org/freedesktop/GeoClue2/Manager,
+
+  # Allow but log any other dbus activity
+  audit dbus bus=system,
+
+  owner @{HOME}/.config/redshift.conf r,
+
+  # Site-specific additions and overrides. See local/README for details.
+  #include <local/usr.bin.redshift>
+}


### PR DESCRIPTION
AppArmor is a Mandatory Access Control mechanism: instead of considering users and groups, like traditional Unix permissions, it considers what process is making the request. More basically, it is a simple way to increase confinement of Redshift by restricting what files redshift can access and other permissions.

With the AppArmor profile in enforcement mode, redshift will not be able to access the users normal files in $HOME -- only its own config file. Furthermore it will be restricted from many other areas of the system that are not necessary to its operation.