### PR TITLE
Time-based adjustment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,3 +54,9 @@ script:
     "$TRAVIS_BUILD_DIR"/root/bin/redshift -l 12:-34 -pv
   - |
     "$TRAVIS_BUILD_DIR"/root/bin/redshift -l 12:-34 -m dummy -vo
+  - |
+    echo -e "[redshift]\ndawn-time=6:30\ndusk-time=18:00-19:30" > time.config
+  - |
+    "$TRAVIS_BUILD_DIR"/root/bin/redshift -c time.config -pv
+  - |
+    "$TRAVIS_BUILD_DIR"/root/bin/redshift -c time.config -m dummy -vo

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -28,7 +28,13 @@ build_script:
 test_script:
 - |
   %APPVEYOR_BUILD_FOLDER%\root\bin\redshift.exe -l 12:-34 -pv
+- |
   %APPVEYOR_BUILD_FOLDER%\root\bin\redshift.exe -l 12:-34 -m dummy -vo
+- ps: Set-Content -Value "[redshift]`ndawn-time=6:30`ndusk-time=18:00-19:30`n" -Path time.config
+- |
+  %APPVEYOR_BUILD_FOLDER%\root\bin\redshift.exe -c time.config -pv
+- |
+  %APPVEYOR_BUILD_FOLDER%\root\bin\redshift.exe -c time.config -m dummy -vo
 
 after_build:
 - ps: |


### PR DESCRIPTION
Implements time-based transition periods for dawn and dusk. If time-based adjustments are desired both `dawn-time` and `dusk-time` must be specified in the configuration file:

```
[redshift]
dawn-time=04:00-05:30
dusk-time=18:00
```

These option can specify an interval like `04:00-05:30` or an instant `18:00` which is equivalent to `18:00-18:00`. The transition between day and night color temperature takes place in the specified interval. Currently times must be specified in 24-hour format and the beginning of dawn must be after midnight and the end of dusk must be before midnight.

When time-based adjustment is specified, no location provider is needed and it will therefore not be initialized and used.