### PR TITLE
Cleanup redshift.c + modules + options

### DIFF
--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -5,7 +5,7 @@ data/applications/redshift.desktop.in
 data/applications/redshift-gtk.desktop.in
 
 src/redshift.c
-
+src/options.c
 src/config-ini.c
 
 src/gamma-drm.c

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -14,6 +14,7 @@ redshift_SOURCES = \
 	gamma-dummy.c gamma-dummy.h \
 	hooks.c hooks.h \
 	location-manual.c location-manual.h \
+	options.c options.h \
 	pipeutils.c pipeutils.h \
 	redshift.c redshift.h \
 	signals.c signals.h \

--- a/src/gamma-drm.c
+++ b/src/gamma-drm.c
@@ -15,6 +15,7 @@
    along with Redshift.  If not, see <http://www.gnu.org/licenses/>.
 
    Copyright (c) 2014  Mattias Andrée <maandree@member.fsf.org>
+   Copyright (c) 2017  Jon Lund Steffensen <jonlst@gmail.com>
 */
 
 #include <stdio.h>
@@ -42,14 +43,18 @@
 
 
 static int
-drm_init(drm_state_t *state)
+drm_init(drm_state_t **state)
 {
 	/* Initialize state. */
-	state->card_num = 0;
-	state->crtc_num = -1;
-	state->fd = -1;
-	state->res = NULL;
-	state->crtcs = NULL;
+        *state = malloc(sizeof(drm_state_t));
+        if (*state == NULL) return -1;
+
+        drm_state_t *s = *state;
+        s->card_num = 0;
+	s->crtc_num = -1;
+	s->fd = -1;
+	s->res = NULL;
+	s->crtcs = NULL;
 
 	return 0;
 }
@@ -206,6 +211,8 @@ drm_free(drm_state_t *state)
 		close(state->fd);
 		state->fd = -1;
 	}
+
+        free(state);
 }
 
 static void

--- a/src/gamma-drm.c
+++ b/src/gamma-drm.c
@@ -38,19 +38,40 @@
   #define O_CLOEXEC  02000000
 #endif
 
+#include <xf86drm.h>
+#include <xf86drmMode.h>
+
 #include "gamma-drm.h"
 #include "colorramp.h"
+
+
+typedef struct {
+	int crtc_num;
+	int crtc_id;
+	int gamma_size;
+	uint16_t* r_gamma;
+	uint16_t* g_gamma;
+	uint16_t* b_gamma;
+} drm_crtc_state_t;
+
+typedef struct {
+	int card_num;
+	int crtc_num;
+	int fd;
+	drmModeRes* res;
+	drm_crtc_state_t* crtcs;
+} drm_state_t;
 
 
 static int
 drm_init(drm_state_t **state)
 {
 	/* Initialize state. */
-        *state = malloc(sizeof(drm_state_t));
-        if (*state == NULL) return -1;
+	*state = malloc(sizeof(drm_state_t));
+	if (*state == NULL) return -1;
 
-        drm_state_t *s = *state;
-        s->card_num = 0;
+	drm_state_t *s = *state;
+	s->card_num = 0;
 	s->crtc_num = -1;
 	s->fd = -1;
 	s->res = NULL;
@@ -212,7 +233,7 @@ drm_free(drm_state_t *state)
 		state->fd = -1;
 	}
 
-        free(state);
+	free(state);
 }
 
 static void

--- a/src/gamma-drm.c
+++ b/src/gamma-drm.c
@@ -41,7 +41,7 @@
 #include "colorramp.h"
 
 
-int
+static int
 drm_init(drm_state_t *state)
 {
 	/* Initialize state. */
@@ -54,7 +54,7 @@ drm_init(drm_state_t *state)
 	return 0;
 }
 
-int
+static int
 drm_start(drm_state_t *state)
 {
 	/* Acquire access to a graphics card. */
@@ -172,7 +172,7 @@ drm_start(drm_state_t *state)
 	return 0;
 }
 
-void
+static void
 drm_restore(drm_state_t *state)
 {
 	drm_crtc_state_t *crtcs = state->crtcs;
@@ -185,7 +185,7 @@ drm_restore(drm_state_t *state)
 	}
 }
 
-void
+static void
 drm_free(drm_state_t *state)
 {
 	if (state->crtcs != NULL) {
@@ -208,7 +208,7 @@ drm_free(drm_state_t *state)
 	}
 }
 
-void
+static void
 drm_print_help(FILE *f)
 {
 	fputs(_("Adjust gamma ramps with Direct Rendering Manager.\n"), f);
@@ -221,7 +221,7 @@ drm_print_help(FILE *f)
 	fputs("\n", f);
 }
 
-int
+static int
 drm_set_option(drm_state_t *state, const char *key, const char *value)
 {
 	if (strcasecmp(key, "card") == 0) {
@@ -240,7 +240,7 @@ drm_set_option(drm_state_t *state, const char *key, const char *value)
 	return 0;
 }
 
-int
+static int
 drm_set_temperature(drm_state_t *state, const color_setting_t *setting)
 {
 	drm_crtc_state_t *crtcs = state->crtcs;
@@ -288,3 +288,15 @@ drm_set_temperature(drm_state_t *state, const color_setting_t *setting)
 
 	return 0;
 }
+
+
+const gamma_method_t drm_gamma_method = {
+	"drm", 0,
+	(gamma_method_init_func *)drm_init,
+	(gamma_method_start_func *)drm_start,
+	(gamma_method_free_func *)drm_free,
+	(gamma_method_print_help_func *)drm_print_help,
+	(gamma_method_set_option_func *)drm_set_option,
+	(gamma_method_restore_func *)drm_restore,
+	(gamma_method_set_temperature_func *)drm_set_temperature
+};

--- a/src/gamma-drm.h
+++ b/src/gamma-drm.h
@@ -15,36 +15,13 @@
    along with Redshift.  If not, see <http://www.gnu.org/licenses/>.
 
    Copyright (c) 2014  Mattias Andrée <maandree@member.fsf.org>
+   Copyright (c) 2017  Jon Lund Steffensen <jonlst@gmail.com>
 */
 
 #ifndef REDSHIFT_GAMMA_DRM_H
 #define REDSHIFT_GAMMA_DRM_H
 
-#include <stdint.h>
-
-#include <xf86drm.h>
-#include <xf86drmMode.h>
-
 #include "redshift.h"
-
-
-typedef struct {
-	int crtc_num;
-	int crtc_id;
-	int gamma_size;
-	uint16_t* r_gamma;
-	uint16_t* g_gamma;
-	uint16_t* b_gamma;
-} drm_crtc_state_t;
-
-typedef struct {
-	int card_num;
-	int crtc_num;
-	int fd;
-	drmModeRes* res;
-	drm_crtc_state_t* crtcs;
-} drm_state_t;
-
 
 extern const gamma_method_t drm_gamma_method;
 

--- a/src/gamma-drm.h
+++ b/src/gamma-drm.h
@@ -46,16 +46,6 @@ typedef struct {
 } drm_state_t;
 
 
-int drm_init(drm_state_t *state);
-int drm_start(drm_state_t *state);
-void drm_free(drm_state_t *state);
-
-void drm_print_help(FILE *f);
-int drm_set_option(drm_state_t *state, const char *key, const char *value);
-
-void drm_restore(drm_state_t *state);
-int drm_set_temperature(drm_state_t *state,
-			const color_setting_t *setting);
-
+extern const gamma_method_t drm_gamma_method;
 
 #endif /* ! REDSHIFT_GAMMA_DRM_H */

--- a/src/gamma-dummy.c
+++ b/src/gamma-dummy.c
@@ -31,8 +31,9 @@
 
 
 static int
-gamma_dummy_init(void *state)
+gamma_dummy_init(void **state)
 {
+	*state = NULL;
 	return 0;
 }
 

--- a/src/gamma-dummy.c
+++ b/src/gamma-dummy.c
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with Redshift.  If not, see <http://www.gnu.org/licenses/>.
 
-   Copyright (c) 2013-2014  Jon Lund Steffensen <jonlst@gmail.com>
+   Copyright (c) 2013-2017  Jon Lund Steffensen <jonlst@gmail.com>
 */
 
 #include <stdio.h>
@@ -30,46 +30,58 @@
 #include "redshift.h"
 
 
-int
+static int
 gamma_dummy_init(void *state)
 {
 	return 0;
 }
 
-int
+static int
 gamma_dummy_start(void *state)
 {
 	fputs(_("WARNING: Using dummy gamma method! Display will not be affected by this gamma method.\n"), stderr);
 	return 0;
 }
 
-void
+static void
 gamma_dummy_restore(void *state)
 {
 }
 
-void
+static void
 gamma_dummy_free(void *state)
 {
 }
 
-void
+static void
 gamma_dummy_print_help(FILE *f)
 {
 	fputs(_("Does not affect the display but prints the color temperature to the terminal.\n"), f);
 	fputs("\n", f);
 }
 
-int
+static int
 gamma_dummy_set_option(void *state, const char *key, const char *value)
 {
 	fprintf(stderr, _("Unknown method parameter: `%s'.\n"), key);
 	return -1;
 }
 
-int
+static int
 gamma_dummy_set_temperature(void *state, const color_setting_t *setting)
 {
 	printf(_("Temperature: %i\n"), setting->temperature);
 	return 0;
 }
+
+
+const gamma_method_t dummy_gamma_method = {
+	"dummy", 0,
+	(gamma_method_init_func *)gamma_dummy_init,
+	(gamma_method_start_func *)gamma_dummy_start,
+	(gamma_method_free_func *)gamma_dummy_free,
+	(gamma_method_print_help_func *)gamma_dummy_print_help,
+	(gamma_method_set_option_func *)gamma_dummy_set_option,
+	(gamma_method_restore_func *)gamma_dummy_restore,
+	(gamma_method_set_temperature_func *)gamma_dummy_set_temperature
+};

--- a/src/gamma-dummy.h
+++ b/src/gamma-dummy.h
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with Redshift.  If not, see <http://www.gnu.org/licenses/>.
 
-   Copyright (c) 2013-2014  Jon Lund Steffensen <jonlst@gmail.com>
+   Copyright (c) 2013-2017  Jon Lund Steffensen <jonlst@gmail.com>
 */
 
 #ifndef REDSHIFT_GAMMA_DUMMY_H
@@ -23,16 +23,7 @@
 #include "redshift.h"
 
 
-int gamma_dummy_init(void *state);
-int gamma_dummy_start(void *state);
-void gamma_dummy_free(void *state);
-
-void gamma_dummy_print_help(FILE *f);
-int gamma_dummy_set_option(void *state, const char *key, const char *value);
-
-void gamma_dummy_restore(void *state);
-int gamma_dummy_set_temperature(void *state,
-				const color_setting_t *setting);
+extern const gamma_method_t dummy_gamma_method;
 
 
 #endif /* ! REDSHIFT_GAMMA_DUMMY_H */

--- a/src/gamma-dummy.h
+++ b/src/gamma-dummy.h
@@ -22,8 +22,6 @@
 
 #include "redshift.h"
 
-
 extern const gamma_method_t dummy_gamma_method;
-
 
 #endif /* ! REDSHIFT_GAMMA_DUMMY_H */

--- a/src/gamma-quartz.c
+++ b/src/gamma-quartz.c
@@ -37,6 +37,19 @@
 #include "colorramp.h"
 
 
+typedef struct {
+	CGDirectDisplayID display;
+	uint32_t ramp_size;
+	float *saved_ramps;
+} quartz_display_state_t;
+
+typedef struct {
+	quartz_display_state_t *displays;
+	uint32_t display_count;
+	int preserve;
+} quartz_state_t;
+
+
 static int
 quartz_init(quartz_state_t **state)
 {

--- a/src/gamma-quartz.c
+++ b/src/gamma-quartz.c
@@ -38,10 +38,14 @@
 
 
 static int
-quartz_init(quartz_state_t *state)
+quartz_init(quartz_state_t **state)
 {
-	state->preserve = 1;
-	state->displays = NULL;
+	*state = malloc(sizeof(quartz_state_t));
+	if (*state == NULL) return -1;
+
+	quartz_state_t *s = *state;
+	s->preserve = 1;
+	s->displays = NULL;
 
 	return 0;
 }
@@ -49,7 +53,6 @@ quartz_init(quartz_state_t *state)
 static int
 quartz_start(quartz_state_t *state)
 {
-	int r;
 	CGError error;
 	uint32_t display_count;
 
@@ -147,6 +150,7 @@ quartz_free(quartz_state_t *state)
 		}
 	}
 	free(state->displays);
+	free(state);
 }
 
 static void

--- a/src/gamma-quartz.c
+++ b/src/gamma-quartz.c
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with Redshift.  If not, see <http://www.gnu.org/licenses/>.
 
-   Copyright (c) 2014  Jon Lund Steffensen <jonlst@gmail.com>
+   Copyright (c) 2014-2017  Jon Lund Steffensen <jonlst@gmail.com>
 */
 
 #ifdef HAVE_CONFIG_H
@@ -37,7 +37,7 @@
 #include "colorramp.h"
 
 
-int
+static int
 quartz_init(quartz_state_t *state)
 {
 	state->preserve = 1;
@@ -46,7 +46,7 @@ quartz_init(quartz_state_t *state)
 	return 0;
 }
 
-int
+static int
 quartz_start(quartz_state_t *state)
 {
 	int r;
@@ -132,13 +132,13 @@ quartz_start(quartz_state_t *state)
 	return 0;
 }
 
-void
+static void
 quartz_restore(quartz_state_t *state)
 {
 	CGDisplayRestoreColorSyncSettings();
 }
 
-void
+static void
 quartz_free(quartz_state_t *state)
 {
 	if (state->displays != NULL) {
@@ -149,7 +149,7 @@ quartz_free(quartz_state_t *state)
 	free(state->displays);
 }
 
-void
+static void
 quartz_print_help(FILE *f)
 {
 	fputs(_("Adjust gamma ramps on OSX using Quartz.\n"), f);
@@ -163,7 +163,7 @@ quartz_print_help(FILE *f)
 	fputs("\n", f);
 }
 
-int
+static int
 quartz_set_option(quartz_state_t *state, const char *key, const char *value)
 {
 	if (strcasecmp(key, "preserve") == 0) {
@@ -222,7 +222,7 @@ quartz_set_temperature_for_display(quartz_state_t *state, int display_index,
 	free(gamma_ramps);
 }
 
-int
+static int
 quartz_set_temperature(quartz_state_t *state,
 		       const color_setting_t *setting)
 {
@@ -232,3 +232,15 @@ quartz_set_temperature(quartz_state_t *state,
 
 	return 0;
 }
+
+
+const gamma_method_t quartz_gamma_method = {
+	"quartz", 1,
+	(gamma_method_init_func *)quartz_init,
+	(gamma_method_start_func *)quartz_start,
+	(gamma_method_free_func *)quartz_free,
+	(gamma_method_print_help_func *)quartz_print_help,
+	(gamma_method_set_option_func *)quartz_set_option,
+	(gamma_method_restore_func *)quartz_restore,
+	(gamma_method_set_temperature_func *)quartz_set_temperature
+};

--- a/src/gamma-quartz.h
+++ b/src/gamma-quartz.h
@@ -20,25 +20,7 @@
 #ifndef REDSHIFT_GAMMA_QUARTZ_H
 #define REDSHIFT_GAMMA_QUARTZ_H
 
-#include <stdint.h>
-
-#include <ApplicationServices/ApplicationServices.h>
-
 #include "redshift.h"
-
-
-typedef struct {
-	CGDirectDisplayID display;
-	uint32_t ramp_size;
-	float *saved_ramps;
-} quartz_display_state_t;
-
-typedef struct {
-	quartz_display_state_t *displays;
-	uint32_t display_count;
-	int preserve;
-} quartz_state_t;
-
 
 extern const gamma_method_t quartz_gamma_method;
 

--- a/src/gamma-quartz.h
+++ b/src/gamma-quartz.h
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with Redshift.  If not, see <http://www.gnu.org/licenses/>.
 
-   Copyright (c) 2014  Jon Lund Steffensen <jonlst@gmail.com>
+   Copyright (c) 2014-2017  Jon Lund Steffensen <jonlst@gmail.com>
 */
 
 #ifndef REDSHIFT_GAMMA_QUARTZ_H
@@ -40,17 +40,6 @@ typedef struct {
 } quartz_state_t;
 
 
-int quartz_init(quartz_state_t *state);
-int quartz_start(quartz_state_t *state);
-void quartz_free(quartz_state_t *state);
-
-void quartz_print_help(FILE *f);
-int quartz_set_option(quartz_state_t *state, const char *key,
-		      const char *value);
-
-void quartz_restore(quartz_state_t *state);
-int quartz_set_temperature(quartz_state_t *state,
-			   const color_setting_t *setting);
-
+extern const gamma_method_t quartz_gamma_method;
 
 #endif /* ! REDSHIFT_GAMMA_QUARTZ_H */

--- a/src/gamma-randr.c
+++ b/src/gamma-randr.c
@@ -42,6 +42,25 @@
 #define RANDR_VERSION_MINOR  3
 
 
+typedef struct {
+	xcb_randr_crtc_t crtc;
+	unsigned int ramp_size;
+	uint16_t *saved_ramps;
+} randr_crtc_state_t;
+
+typedef struct {
+	xcb_connection_t *conn;
+	xcb_screen_t *screen;
+	int preferred_screen;
+	int preserve;
+	int screen_num;
+	int crtc_num_count;
+	int* crtc_num;
+	unsigned int crtc_count;
+	randr_crtc_state_t *crtcs;
+} randr_state_t;
+
+
 static int
 randr_init(randr_state_t **state)
 {

--- a/src/gamma-randr.c
+++ b/src/gamma-randr.c
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with Redshift.  If not, see <http://www.gnu.org/licenses/>.
 
-   Copyright (c) 2010-2014  Jon Lund Steffensen <jonlst@gmail.com>
+   Copyright (c) 2010-2017  Jon Lund Steffensen <jonlst@gmail.com>
 */
 
 #include <stdio.h>
@@ -42,7 +42,7 @@
 #define RANDR_VERSION_MINOR  3
 
 
-int
+static int
 randr_init(randr_state_t *state)
 {
 	/* Initialize state. */
@@ -91,7 +91,7 @@ randr_init(randr_state_t *state)
 	return 0;
 }
 
-int
+static int
 randr_start(randr_state_t *state)
 {
 	xcb_generic_error_t *error;
@@ -228,7 +228,7 @@ randr_start(randr_state_t *state)
 	return 0;
 }
 
-void
+static void
 randr_restore(randr_state_t *state)
 {
 	xcb_generic_error_t *error;
@@ -257,7 +257,7 @@ randr_restore(randr_state_t *state)
 	}
 }
 
-void
+static void
 randr_free(randr_state_t *state)
 {
 	/* Free CRTC state */
@@ -271,7 +271,7 @@ randr_free(randr_state_t *state)
 	xcb_disconnect(state->conn);
 }
 
-void
+static void
 randr_print_help(FILE *f)
 {
 	fputs(_("Adjust gamma ramps with the X RANDR extension.\n"), f);
@@ -287,7 +287,7 @@ randr_print_help(FILE *f)
 	fputs("\n", f);
 }
 
-int
+static int
 randr_set_option(randr_state_t *state, const char *key, const char *value)
 {
 	if (strcasecmp(key, "screen") == 0) {
@@ -416,7 +416,7 @@ randr_set_temperature_for_crtc(randr_state_t *state, int crtc_num,
 	return 0;
 }
 
-int
+static int
 randr_set_temperature(randr_state_t *state,
 		      const color_setting_t *setting)
 {
@@ -440,3 +440,15 @@ randr_set_temperature(randr_state_t *state,
 
 	return 0;
 }
+
+
+const gamma_method_t randr_gamma_method = {
+	"randr", 1,
+	(gamma_method_init_func *)randr_init,
+	(gamma_method_start_func *)randr_start,
+	(gamma_method_free_func *)randr_free,
+	(gamma_method_print_help_func *)randr_print_help,
+	(gamma_method_set_option_func *)randr_set_option,
+	(gamma_method_restore_func *)randr_restore,
+	(gamma_method_set_temperature_func *)randr_set_temperature
+};

--- a/src/gamma-randr.h
+++ b/src/gamma-randr.h
@@ -48,16 +48,7 @@ typedef struct {
 } randr_state_t;
 
 
-int randr_init(randr_state_t *state);
-int randr_start(randr_state_t *state);
-void randr_free(randr_state_t *state);
-
-void randr_print_help(FILE *f);
-int randr_set_option(randr_state_t *state, const char *key, const char *value);
-
-void randr_restore(randr_state_t *state);
-int randr_set_temperature(randr_state_t *state,
-			  const color_setting_t *setting);
+extern const gamma_method_t randr_gamma_method;
 
 
 #endif /* ! REDSHIFT_GAMMA_RANDR_H */

--- a/src/gamma-randr.h
+++ b/src/gamma-randr.h
@@ -14,41 +14,14 @@
    You should have received a copy of the GNU General Public License
    along with Redshift.  If not, see <http://www.gnu.org/licenses/>.
 
-   Copyright (c) 2010-2014  Jon Lund Steffensen <jonlst@gmail.com>
+   Copyright (c) 2010-2017  Jon Lund Steffensen <jonlst@gmail.com>
 */
 
 #ifndef REDSHIFT_GAMMA_RANDR_H
 #define REDSHIFT_GAMMA_RANDR_H
 
-#include <stdio.h>
-#include <stdint.h>
-
-#include <xcb/xcb.h>
-#include <xcb/randr.h>
-
 #include "redshift.h"
 
-
-typedef struct {
-	xcb_randr_crtc_t crtc;
-	unsigned int ramp_size;
-	uint16_t *saved_ramps;
-} randr_crtc_state_t;
-
-typedef struct {
-	xcb_connection_t *conn;
-	xcb_screen_t *screen;
-	int preferred_screen;
-	int preserve;
-	int screen_num;
-	int crtc_num_count;
-	int* crtc_num;
-	unsigned int crtc_count;
-	randr_crtc_state_t *crtcs;
-} randr_state_t;
-
-
 extern const gamma_method_t randr_gamma_method;
-
 
 #endif /* ! REDSHIFT_GAMMA_RANDR_H */

--- a/src/gamma-vidmode.c
+++ b/src/gamma-vidmode.c
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with Redshift.  If not, see <http://www.gnu.org/licenses/>.
 
-   Copyright (c) 2010-2014  Jon Lund Steffensen <jonlst@gmail.com>
+   Copyright (c) 2010-2017  Jon Lund Steffensen <jonlst@gmail.com>
 */
 
 #include <stdlib.h>
@@ -37,7 +37,7 @@
 #include "colorramp.h"
 
 
-int
+static int
 vidmode_init(vidmode_state_t *state)
 {
 	state->screen_num = -1;
@@ -56,7 +56,7 @@ vidmode_init(vidmode_state_t *state)
 	return 0;
 }
 
-int
+static int
 vidmode_start(vidmode_state_t *state)
 {
 	int r;
@@ -113,7 +113,7 @@ vidmode_start(vidmode_state_t *state)
 	return 0;
 }
 
-void
+static void
 vidmode_free(vidmode_state_t *state)
 {
 	/* Free saved ramps */
@@ -123,7 +123,7 @@ vidmode_free(vidmode_state_t *state)
 	XCloseDisplay(state->display);
 }
 
-void
+static void
 vidmode_print_help(FILE *f)
 {
 	fputs(_("Adjust gamma ramps with the X VidMode extension.\n"), f);
@@ -138,7 +138,7 @@ vidmode_print_help(FILE *f)
 	fputs("\n", f);
 }
 
-int
+static int
 vidmode_set_option(vidmode_state_t *state, const char *key, const char *value)
 {
 	if (strcasecmp(key, "screen") == 0) {
@@ -153,7 +153,7 @@ vidmode_set_option(vidmode_state_t *state, const char *key, const char *value)
 	return 0;
 }
 
-void
+static void
 vidmode_restore(vidmode_state_t *state)
 {
 	uint16_t *gamma_r = &state->saved_ramps[0*state->ramp_size];
@@ -170,7 +170,7 @@ vidmode_restore(vidmode_state_t *state)
 	}
 }
 
-int
+static int
 vidmode_set_temperature(vidmode_state_t *state,
 			const color_setting_t *setting)
 {
@@ -220,3 +220,15 @@ vidmode_set_temperature(vidmode_state_t *state,
 
 	return 0;
 }
+
+
+const gamma_method_t vidmode_gamma_method = {
+	"vidmode", 1,
+	(gamma_method_init_func *)vidmode_init,
+	(gamma_method_start_func *)vidmode_start,
+	(gamma_method_free_func *)vidmode_free,
+	(gamma_method_print_help_func *)vidmode_print_help,
+	(gamma_method_set_option_func *)vidmode_set_option,
+	(gamma_method_restore_func *)vidmode_restore,
+	(gamma_method_set_temperature_func *)vidmode_set_temperature
+};

--- a/src/gamma-vidmode.c
+++ b/src/gamma-vidmode.c
@@ -38,18 +38,21 @@
 
 
 static int
-vidmode_init(vidmode_state_t *state)
+vidmode_init(vidmode_state_t **state)
 {
-	state->screen_num = -1;
-	state->saved_ramps = NULL;
+	*state = malloc(sizeof(vidmode_state_t));
+	if (*state == NULL) return -1;
 
-	state->preserve = 1;
+	vidmode_state_t *s = *state;
+	s->screen_num = -1;
+	s->saved_ramps = NULL;
+
+	s->preserve = 1;
 
 	/* Open display */
-	state->display = XOpenDisplay(NULL);
-	if (state->display == NULL) {
-		fprintf(stderr, _("X request failed: %s\n"),
-			"XOpenDisplay");
+	s->display = XOpenDisplay(NULL);
+	if (s->display == NULL) {
+		fprintf(stderr, _("X request failed: %s\n"), "XOpenDisplay");
 		return -1;
 	}
 
@@ -121,6 +124,8 @@ vidmode_free(vidmode_state_t *state)
 
 	/* Close display connection */
 	XCloseDisplay(state->display);
+
+	free(state);
 }
 
 static void

--- a/src/gamma-vidmode.c
+++ b/src/gamma-vidmode.c
@@ -37,6 +37,15 @@
 #include "colorramp.h"
 
 
+typedef struct {
+	Display *display;
+	int preserve;
+	int screen_num;
+	int ramp_size;
+	uint16_t *saved_ramps;
+} vidmode_state_t;
+
+
 static int
 vidmode_init(vidmode_state_t **state)
 {

--- a/src/gamma-vidmode.h
+++ b/src/gamma-vidmode.h
@@ -22,21 +22,6 @@
 
 #include "redshift.h"
 
-#include <stdio.h>
-#include <stdint.h>
-
-#include <X11/Xlib.h>
-
-typedef struct {
-	Display *display;
-	int preserve;
-	int screen_num;
-	int ramp_size;
-	uint16_t *saved_ramps;
-} vidmode_state_t;
-
-
 extern const gamma_method_t vidmode_gamma_method;
-
 
 #endif /* ! REDSHIFT_GAMMA_VIDMODE_H */

--- a/src/gamma-vidmode.h
+++ b/src/gamma-vidmode.h
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with Redshift.  If not, see <http://www.gnu.org/licenses/>.
 
-   Copyright (c) 2010-2014  Jon Lund Steffensen <jonlst@gmail.com>
+   Copyright (c) 2010-2017  Jon Lund Steffensen <jonlst@gmail.com>
 */
 
 #ifndef REDSHIFT_GAMMA_VIDMODE_H
@@ -36,17 +36,7 @@ typedef struct {
 } vidmode_state_t;
 
 
-int vidmode_init(vidmode_state_t *state);
-int vidmode_start(vidmode_state_t *state);
-void vidmode_free(vidmode_state_t *state);
-
-void vidmode_print_help(FILE *f);
-int vidmode_set_option(vidmode_state_t *state, const char *key,
-		       const char *value);
-
-void vidmode_restore(vidmode_state_t *state);
-int vidmode_set_temperature(vidmode_state_t *state,
-			    const color_setting_t *setting);
+extern const gamma_method_t vidmode_gamma_method;
 
 
 #endif /* ! REDSHIFT_GAMMA_VIDMODE_H */

--- a/src/gamma-w32gdi.c
+++ b/src/gamma-w32gdi.c
@@ -41,10 +41,14 @@
 
 
 static int
-w32gdi_init(w32gdi_state_t *state)
+w32gdi_init(w32gdi_state_t **state)
 {
-	state->saved_ramps = NULL;
-	state->preserve = 1;
+	*state = malloc(sizeof(w32gdi_state_t));
+	if (state == NULL) return -1;
+
+	w32gdi_state_t *s = *state;
+	s->saved_ramps = NULL;
+	s->preserve = 1;
 
 	return 0;
 }
@@ -96,6 +100,8 @@ w32gdi_free(w32gdi_state_t *state)
 {
 	/* Free saved ramps */
 	free(state->saved_ramps);
+
+	free(state);
 }
 
 

--- a/src/gamma-w32gdi.c
+++ b/src/gamma-w32gdi.c
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with Redshift.  If not, see <http://www.gnu.org/licenses/>.
 
-   Copyright (c) 2010-2014  Jon Lund Steffensen <jonlst@gmail.com>
+   Copyright (c) 2010-2017  Jon Lund Steffensen <jonlst@gmail.com>
 */
 
 #include <stdio.h>
@@ -40,7 +40,7 @@
 #define MAX_ATTEMPTS  10
 
 
-int
+static int
 w32gdi_init(w32gdi_state_t *state)
 {
 	state->saved_ramps = NULL;
@@ -49,7 +49,7 @@ w32gdi_init(w32gdi_state_t *state)
 	return 0;
 }
 
-int
+static int
 w32gdi_start(w32gdi_state_t *state)
 {
 	BOOL r;
@@ -91,7 +91,7 @@ w32gdi_start(w32gdi_state_t *state)
 	return 0;
 }
 
-void
+static void
 w32gdi_free(w32gdi_state_t *state)
 {
 	/* Free saved ramps */
@@ -99,7 +99,7 @@ w32gdi_free(w32gdi_state_t *state)
 }
 
 
-void
+static void
 w32gdi_print_help(FILE *f)
 {
 	fputs(_("Adjust gamma ramps with the Windows GDI.\n"), f);
@@ -113,7 +113,7 @@ w32gdi_print_help(FILE *f)
 	fputs("\n", f);
 }
 
-int
+static int
 w32gdi_set_option(w32gdi_state_t *state, const char *key, const char *value)
 {
 	if (strcasecmp(key, "preserve") == 0) {
@@ -126,7 +126,7 @@ w32gdi_set_option(w32gdi_state_t *state, const char *key, const char *value)
 	return 0;
 }
 
-void
+static void
 w32gdi_restore(w32gdi_state_t *state)
 {
 	/* Open device context */
@@ -150,7 +150,7 @@ w32gdi_restore(w32gdi_state_t *state)
 	ReleaseDC(NULL, hDC);
 }
 
-int
+static int
 w32gdi_set_temperature(w32gdi_state_t *state,
 		       const color_setting_t *setting)
 {
@@ -215,3 +215,15 @@ w32gdi_set_temperature(w32gdi_state_t *state,
 
 	return 0;
 }
+
+
+const gamma_method_t w32gdi_gamma_method = {
+	"wingdi", 1,
+	(gamma_method_init_func *)w32gdi_init,
+	(gamma_method_start_func *)w32gdi_start,
+	(gamma_method_free_func *)w32gdi_free,
+	(gamma_method_print_help_func *)w32gdi_print_help,
+	(gamma_method_set_option_func *)w32gdi_set_option,
+	(gamma_method_restore_func *)w32gdi_restore,
+	(gamma_method_set_temperature_func *)w32gdi_set_temperature
+};

--- a/src/gamma-w32gdi.c
+++ b/src/gamma-w32gdi.c
@@ -40,6 +40,12 @@
 #define MAX_ATTEMPTS  10
 
 
+typedef struct {
+	WORD *saved_ramps;
+	int preserve;
+} w32gdi_state_t;
+
+
 static int
 w32gdi_init(w32gdi_state_t **state)
 {

--- a/src/gamma-w32gdi.h
+++ b/src/gamma-w32gdi.h
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with Redshift.  If not, see <http://www.gnu.org/licenses/>.
 
-   Copyright (c) 2010-2014  Jon Lund Steffensen <jonlst@gmail.com>
+   Copyright (c) 2010-2017  Jon Lund Steffensen <jonlst@gmail.com>
 */
 
 #ifndef REDSHIFT_GAMMA_W32GDI_H
@@ -32,17 +32,7 @@ typedef struct {
 } w32gdi_state_t;
 
 
-int w32gdi_init(w32gdi_state_t *state);
-int w32gdi_start(w32gdi_state_t *state);
-void w32gdi_free(w32gdi_state_t *state);
-
-void w32gdi_print_help(FILE *f);
-int w32gdi_set_option(w32gdi_state_t *state, const char *key,
-		      const char *value);
-
-void w32gdi_restore(w32gdi_state_t *state);
-int w32gdi_set_temperature(w32gdi_state_t *state,
-			   const color_setting_t *color);
+extern const gamma_method_t w32gdi_gamma_method;
 
 
 #endif /* ! REDSHIFT_GAMMA_W32GDI_H */

--- a/src/gamma-w32gdi.h
+++ b/src/gamma-w32gdi.h
@@ -20,19 +20,8 @@
 #ifndef REDSHIFT_GAMMA_W32GDI_H
 #define REDSHIFT_GAMMA_W32GDI_H
 
-#include <windows.h>
-#include <wingdi.h>
-
 #include "redshift.h"
 
-
-typedef struct {
-	WORD *saved_ramps;
-	int preserve;
-} w32gdi_state_t;
-
-
 extern const gamma_method_t w32gdi_gamma_method;
-
 
 #endif /* ! REDSHIFT_GAMMA_W32GDI_H */

--- a/src/location-corelocation.h
+++ b/src/location-corelocation.h
@@ -37,20 +37,7 @@ typedef struct {
 } location_corelocation_state_t;
 
 
-int location_corelocation_init(location_corelocation_state_t *state);
-int location_corelocation_start(location_corelocation_state_t *state);
-void location_corelocation_free(location_corelocation_state_t *state);
-
-void location_corelocation_print_help(FILE *f);
-int location_corelocation_set_option(
-	location_corelocation_state_t *state,
-	const char *key, const char *value);
-
-int location_corelocation_get_fd(
-	location_corelocation_state_t *state);
-int location_corelocation_handle(
-	location_corelocation_state_t *state,
-	location_t *location, int *available);
+extern const location_provider_t corelocation_location_provider;
 
 
 #endif /* ! REDSHIFT_LOCATION_CORELOCATION_H */

--- a/src/location-corelocation.h
+++ b/src/location-corelocation.h
@@ -20,24 +20,8 @@
 #ifndef REDSHIFT_LOCATION_CORELOCATION_H
 #define REDSHIFT_LOCATION_CORELOCATION_H
 
-#include <stdio.h>
-
 #include "redshift.h"
 
-typedef struct location_corelocation_private location_corelocation_private_t;
-
-typedef struct {
-	location_corelocation_private_t *private;
-	int pipe_fd_read;
-	int pipe_fd_write;
-	int available;
-	int error;
-	float latitude;
-	float longitude;
-} location_corelocation_state_t;
-
-
 extern const location_provider_t corelocation_location_provider;
-
 
 #endif /* ! REDSHIFT_LOCATION_CORELOCATION_H */

--- a/src/location-corelocation.m
+++ b/src/location-corelocation.m
@@ -172,13 +172,13 @@ pipe_close_callback(
 @end
 
 
-int
+static int
 location_corelocation_init(location_corelocation_state_t *state)
 {
   return 0;
 }
 
-int
+static int
 location_corelocation_start(location_corelocation_state_t *state)
 {
   state->pipe_fd_read = -1;
@@ -215,7 +215,7 @@ location_corelocation_start(location_corelocation_state_t *state)
   return 0;
 }
 
-void
+static void
 location_corelocation_free(location_corelocation_state_t *state)
 {
   if (state->pipe_fd_read != -1) {
@@ -225,14 +225,14 @@ location_corelocation_free(location_corelocation_state_t *state)
   free(state->private);
 }
 
-void
+static void
 location_corelocation_print_help(FILE *f)
 {
   fputs(_("Use the location as discovered by the Corelocation provider.\n"), f);
   fputs("\n", f);
 }
 
-int
+static int
 location_corelocation_set_option(
     location_corelocation_state_t *state, const char *key, const char *value)
 {
@@ -240,13 +240,14 @@ location_corelocation_set_option(
   return -1;
 }
 
-int
+static int
 location_corelocation_get_fd(location_corelocation_state_t *state)
 {
   return state->pipe_fd_read;
 }
 
-int location_corelocation_handle(
+static int
+location_corelocation_handle(
     location_corelocation_state_t *state,
     location_t *location, int *available)
 {
@@ -265,3 +266,15 @@ int location_corelocation_handle(
 
   return 0;
 }
+
+
+const location_provider_t corelocation_location_provider = {
+  "corelocation",
+  (location_provider_init_func *)location_corelocation_init,
+  (location_provider_start_func *)location_corelocation_start,
+  (location_provider_free_func *)location_corelocation_free,
+  (location_provider_print_help_func *)location_corelocation_print_help,
+  (location_provider_set_option_func *)location_corelocation_set_option,
+  (location_provider_get_fd_func *)location_corelocation_get_fd,
+  (location_provider_handle_func *)location_corelocation_handle
+};

--- a/src/location-corelocation.m
+++ b/src/location-corelocation.m
@@ -173,8 +173,10 @@ pipe_close_callback(
 
 
 static int
-location_corelocation_init(location_corelocation_state_t *state)
+location_corelocation_init(location_corelocation_state_t **state)
 {
+  *state = malloc(sizeof(location_corelocation_state_t));
+  if (*state == NULL) return -1;
   return 0;
 }
 
@@ -223,6 +225,7 @@ location_corelocation_free(location_corelocation_state_t *state)
   }
 
   free(state->private);
+  free(state);
 }
 
 static void

--- a/src/location-geoclue2.c
+++ b/src/location-geoclue2.c
@@ -285,7 +285,7 @@ on_pipe_closed(GIOChannel *channel, GIOCondition condition, gpointer user_data)
 
 
 /* Run loop for location provider thread. */
-void *
+static void *
 run_geoclue2_loop(void *state_)
 {
 	location_geoclue2_state_t *state = state_;
@@ -324,7 +324,7 @@ run_geoclue2_loop(void *state_)
 	return NULL;
 }
 
-int
+static int
 location_geoclue2_init(location_geoclue2_state_t *state)
 {
 #if !GLIB_CHECK_VERSION(2, 35, 0)
@@ -333,7 +333,7 @@ location_geoclue2_init(location_geoclue2_state_t *state)
 	return 0;
 }
 
-int
+static int
 location_geoclue2_start(location_geoclue2_state_t *state)
 {
 	state->pipe_fd_read = -1;
@@ -362,7 +362,7 @@ location_geoclue2_start(location_geoclue2_state_t *state)
 	return 0;
 }
 
-void
+static void
 location_geoclue2_free(location_geoclue2_state_t *state)
 {
 	if (state->pipe_fd_read != -1) {
@@ -376,7 +376,7 @@ location_geoclue2_free(location_geoclue2_state_t *state)
 	g_mutex_clear(&state->lock);
 }
 
-void
+static void
 location_geoclue2_print_help(FILE *f)
 {
 	fputs(_("Use the location as discovered by a GeoClue2 provider.\n"),
@@ -384,7 +384,7 @@ location_geoclue2_print_help(FILE *f)
 	fputs("\n", f);
 }
 
-int
+static int
 location_geoclue2_set_option(location_geoclue2_state_t *state,
 			     const char *key, const char *value)
 {
@@ -392,13 +392,13 @@ location_geoclue2_set_option(location_geoclue2_state_t *state,
 	return -1;
 }
 
-int
+static int
 location_geoclue2_get_fd(location_geoclue2_state_t *state)
 {
 	return state->pipe_fd_read;
 }
 
-int
+static int
 location_geoclue2_handle(
 	location_geoclue2_state_t *state,
 	location_t *location, int *available)
@@ -418,3 +418,15 @@ location_geoclue2_handle(
 
 	return 0;
 }
+
+
+const location_provider_t geoclue2_location_provider = {
+	"geoclue2",
+	(location_provider_init_func *)location_geoclue2_init,
+	(location_provider_start_func *)location_geoclue2_start,
+	(location_provider_free_func *)location_geoclue2_free,
+	(location_provider_print_help_func *)location_geoclue2_print_help,
+	(location_provider_set_option_func *)location_geoclue2_set_option,
+	(location_provider_get_fd_func *)location_geoclue2_get_fd,
+	(location_provider_handle_func *)location_geoclue2_handle
+};

--- a/src/location-geoclue2.c
+++ b/src/location-geoclue2.c
@@ -325,11 +325,13 @@ run_geoclue2_loop(void *state_)
 }
 
 static int
-location_geoclue2_init(location_geoclue2_state_t *state)
+location_geoclue2_init(location_geoclue2_state_t **state)
 {
 #if !GLIB_CHECK_VERSION(2, 35, 0)
 	g_type_init();
 #endif
+	*state = malloc(sizeof(location_geoclue2_state_t));
+	if (*state == NULL) return -1;
 	return 0;
 }
 
@@ -374,6 +376,8 @@ location_geoclue2_free(location_geoclue2_state_t *state)
 	state->thread = NULL;
 
 	g_mutex_clear(&state->lock);
+
+	free(state);
 }
 
 static void

--- a/src/location-geoclue2.c
+++ b/src/location-geoclue2.c
@@ -38,6 +38,19 @@
 #define DBUS_ACCESS_ERROR  "org.freedesktop.DBus.Error.AccessDenied"
 
 
+typedef struct {
+	GMainLoop *loop;
+	GThread *thread;
+	GMutex lock;
+	int pipe_fd_read;
+	int pipe_fd_write;
+	int available;
+	int error;
+	float latitude;
+	float longitude;
+} location_geoclue2_state_t;
+
+
 /* Print the message explaining denial from GeoClue. */
 static void
 print_denial_message()

--- a/src/location-geoclue2.h
+++ b/src/location-geoclue2.h
@@ -20,26 +20,8 @@
 #ifndef REDSHIFT_LOCATION_GEOCLUE2_H
 #define REDSHIFT_LOCATION_GEOCLUE2_H
 
-#include <stdio.h>
-
-#include <glib.h>
-
 #include "redshift.h"
 
-typedef struct {
-	GMainLoop *loop;
-	GThread *thread;
-	GMutex lock;
-	int pipe_fd_read;
-	int pipe_fd_write;
-	int available;
-	int error;
-	float latitude;
-	float longitude;
-} location_geoclue2_state_t;
-
-
 extern const location_provider_t geoclue2_location_provider;
-
 
 #endif /* ! REDSHIFT_LOCATION_GEOCLUE2_H */

--- a/src/location-geoclue2.h
+++ b/src/location-geoclue2.h
@@ -39,17 +39,7 @@ typedef struct {
 } location_geoclue2_state_t;
 
 
-int location_geoclue2_init(location_geoclue2_state_t *state);
-int location_geoclue2_start(location_geoclue2_state_t *state);
-void location_geoclue2_free(location_geoclue2_state_t *state);
-
-void location_geoclue2_print_help(FILE *f);
-int location_geoclue2_set_option(location_geoclue2_state_t *state,
-				 const char *key, const char *value);
-
-int location_geoclue2_get_fd(location_geoclue2_state_t *state);
-int location_geoclue2_handle(location_geoclue2_state_t *state,
-			     location_t *location, int *available);
+extern const location_provider_t geoclue2_location_provider;
 
 
 #endif /* ! REDSHIFT_LOCATION_GEOCLUE2_H */

--- a/src/location-manual.c
+++ b/src/location-manual.c
@@ -33,6 +33,11 @@
 #endif
 
 
+typedef struct {
+	location_t loc;
+} location_manual_state_t;
+
+
 static int
 location_manual_init(location_manual_state_t **state)
 {

--- a/src/location-manual.c
+++ b/src/location-manual.c
@@ -34,10 +34,14 @@
 
 
 static int
-location_manual_init(location_manual_state_t *state)
+location_manual_init(location_manual_state_t **state)
 {
-	state->loc.lat = NAN;
-	state->loc.lon = NAN;
+	*state = malloc(sizeof(location_manual_state_t));
+	if (*state == NULL) return -1;
+
+	location_manual_state_t *s = *state;
+	s->loc.lat = NAN;
+	s->loc.lon = NAN;
 
 	return 0;
 }
@@ -57,6 +61,7 @@ location_manual_start(location_manual_state_t *state)
 static void
 location_manual_free(location_manual_state_t *state)
 {
+	free(state);
 }
 
 static void

--- a/src/location-manual.c
+++ b/src/location-manual.c
@@ -33,7 +33,7 @@
 #endif
 
 
-int
+static int
 location_manual_init(location_manual_state_t *state)
 {
 	state->loc.lat = NAN;
@@ -42,7 +42,7 @@ location_manual_init(location_manual_state_t *state)
 	return 0;
 }
 
-int
+static int
 location_manual_start(location_manual_state_t *state)
 {
 	/* Latitude and longitude must be set */
@@ -54,12 +54,12 @@ location_manual_start(location_manual_state_t *state)
 	return 0;
 }
 
-void
+static void
 location_manual_free(location_manual_state_t *state)
 {
 }
 
-void
+static void
 location_manual_print_help(FILE *f)
 {
 	fputs(_("Specify location manually.\n"), f);
@@ -75,7 +75,7 @@ location_manual_print_help(FILE *f)
 	fputs("\n", f);
 }
 
-int
+static int
 location_manual_set_option(location_manual_state_t *state, const char *key,
 			   const char *value)
 {
@@ -100,13 +100,13 @@ location_manual_set_option(location_manual_state_t *state, const char *key,
 	return 0;
 }
 
-int
+static int
 location_manual_get_fd(location_manual_state_t *state)
 {
 	return -1;
 }
 
-int
+static int
 location_manual_handle(
 	location_manual_state_t *state, location_t *location, int *available)
 {
@@ -115,3 +115,15 @@ location_manual_handle(
 
 	return 0;
 }
+
+
+const location_provider_t manual_location_provider = {
+	"manual",
+	(location_provider_init_func *)location_manual_init,
+	(location_provider_start_func *)location_manual_start,
+	(location_provider_free_func *)location_manual_free,
+	(location_provider_print_help_func *)location_manual_print_help,
+	(location_provider_set_option_func *)location_manual_set_option,
+	(location_provider_get_fd_func *)location_manual_get_fd,
+	(location_provider_handle_func *)location_manual_handle
+};

--- a/src/location-manual.h
+++ b/src/location-manual.h
@@ -20,17 +20,8 @@
 #ifndef REDSHIFT_LOCATION_MANUAL_H
 #define REDSHIFT_LOCATION_MANUAL_H
 
-#include <stdio.h>
-
 #include "redshift.h"
 
-
-typedef struct {
-	location_t loc;
-} location_manual_state_t;
-
-
 extern const location_provider_t manual_location_provider;
-
 
 #endif /* ! REDSHIFT_LOCATION_MANUAL_H */

--- a/src/location-manual.h
+++ b/src/location-manual.h
@@ -30,17 +30,7 @@ typedef struct {
 } location_manual_state_t;
 
 
-int location_manual_init(location_manual_state_t *state);
-int location_manual_start(location_manual_state_t *state);
-void location_manual_free(location_manual_state_t *state);
-
-void location_manual_print_help(FILE *f);
-int location_manual_set_option(location_manual_state_t *state,
-			       const char *key, const char *value);
-
-int location_manual_get_fd(location_manual_state_t *state);
-int location_manual_handle(
-	location_manual_state_t *state, location_t *location, int *available);
+extern const location_provider_t manual_location_provider;
 
 
 #endif /* ! REDSHIFT_LOCATION_MANUAL_H */

--- a/src/options.c
+++ b/src/options.c
@@ -1,0 +1,672 @@
+/* options.c -- Program options
+   This file is part of Redshift.
+
+   Redshift is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   Redshift is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with Redshift.  If not, see <http://www.gnu.org/licenses/>.
+
+   Copyright (c) 2017  Jon Lund Steffensen <jonlst@gmail.com>
+*/
+
+#ifdef HAVE_CONFIG_H
+# include "config.h"
+#endif
+
+#include <stdlib.h>
+#include <unistd.h>
+#include <string.h>
+#include <errno.h>
+#include <math.h>
+
+#ifdef ENABLE_NLS
+# include <libintl.h>
+# define _(s) gettext(s)
+#else
+# define _(s) s
+#endif
+
+#include "redshift.h"
+#include "config-ini.h"
+#include "options.h"
+#include "solar.h"
+
+/* Angular elevation of the sun at which the color temperature
+   transition period starts and ends (in degress).
+   Transition during twilight, and while the sun is lower than
+   3.0 degrees above the horizon. */
+#define TRANSITION_LOW     SOLAR_CIVIL_TWILIGHT_ELEV
+#define TRANSITION_HIGH    3.0
+
+/* Default values for parameters. */
+#define DEFAULT_DAY_TEMP    6500
+#define DEFAULT_NIGHT_TEMP  4500
+#define DEFAULT_BRIGHTNESS   1.0
+#define DEFAULT_GAMMA        1.0
+
+
+/* A brightness string contains either one floating point value,
+   or two values separated by a colon. */
+static void
+parse_brightness_string(
+	const char *str, float *bright_day, float *bright_night)
+{
+	char *s = strchr(str, ':');
+	if (s == NULL) {
+		/* Same value for day and night. */
+		*bright_day = *bright_night = atof(str);
+	} else {
+		*(s++) = '\0';
+		*bright_day = atof(str);
+		*bright_night = atof(s);
+	}
+}
+
+/* A gamma string contains either one floating point value,
+   or three values separated by colon. */
+static int
+parse_gamma_string(const char *str, float gamma[])
+{
+	char *s = strchr(str, ':');
+	if (s == NULL) {
+		/* Use value for all channels */
+		float g = atof(str);
+		gamma[0] = gamma[1] = gamma[2] = g;
+	} else {
+		/* Parse separate value for each channel */
+		*(s++) = '\0';
+		char *g_s = s;
+		s = strchr(s, ':');
+		if (s == NULL) return -1;
+
+		*(s++) = '\0';
+		gamma[0] = atof(str); /* Red */
+		gamma[1] = atof(g_s); /* Blue */
+		gamma[2] = atof(s); /* Green */
+	}
+
+	return 0;
+}
+
+/* Parse transition time string e.g. "04:50". Returns negative on failure,
+   otherwise the parsed time is returned as seconds since midnight. */
+static int
+parse_transition_time(const char *str, const char **end)
+{
+	const char *min = NULL;
+	errno = 0;
+	long hours = strtol(str, (char **)&min, 10);
+	if (errno != 0 || min == str || min[0] != ':' ||
+	    hours < 0 || hours >= 24) {
+		return -1;
+	}
+
+	min += 1;
+	errno = 0;
+	long minutes = strtol(min, (char **)end, 10);
+	if (errno != 0 || *end == min || minutes < 0 || minutes >= 60) {
+		return -1;
+	}
+
+	return minutes * 60 + hours * 3600;
+}
+
+/* Parse transition range string e.g. "04:50-6:20". Returns negative on
+   failure, otherwise zero. Parsed start and end times are returned as seconds
+   since midnight. */
+static int
+parse_transition_range(const char *str, time_range_t *range)
+{
+	const char *next = NULL;
+	int start_time = parse_transition_time(str, &next);
+	if (start_time < 0) return -1;
+
+	int end_time;
+	if (next[0] == '\0') {
+		end_time = start_time;
+	} else if (next[0] == '-') {
+		next += 1;
+		const char *end = NULL;
+		end_time = parse_transition_time(next, &end);
+		if (end_time < 0 || end[0] != '\0') return -1;
+	} else {
+		return -1;
+	}
+
+	range->start = start_time;
+	range->end = end_time;
+
+	return 0;
+}
+
+/* Print help text. */
+static void
+print_help(const char *program_name)
+{
+	/* TRANSLATORS: help output 1
+	   LAT is latitude, LON is longitude,
+	   DAY is temperature at daytime,
+	   NIGHT is temperature at night
+	   no-wrap */
+	printf(_("Usage: %s -l LAT:LON -t DAY:NIGHT [OPTIONS...]\n"),
+		program_name);
+	fputs("\n", stdout);
+
+	/* TRANSLATORS: help output 2
+	   no-wrap */
+	fputs(_("Set color temperature of display"
+		" according to time of day.\n"), stdout);
+	fputs("\n", stdout);
+
+	/* TRANSLATORS: help output 3
+	   no-wrap */
+	fputs(_("  -h\t\tDisplay this help message\n"
+		"  -v\t\tVerbose output\n"
+		"  -V\t\tShow program version\n"), stdout);
+	fputs("\n", stdout);
+
+	/* TRANSLATORS: help output 4
+	   `list' must not be translated
+	   no-wrap */
+	fputs(_("  -b DAY:NIGHT\tScreen brightness to apply (between 0.1 and 1.0)\n"
+		"  -c FILE\tLoad settings from specified configuration file\n"
+		"  -g R:G:B\tAdditional gamma correction to apply\n"
+		"  -l LAT:LON\tYour current location\n"
+		"  -l PROVIDER\tSelect provider for automatic"
+		" location updates\n"
+		"  \t\t(Type `list' to see available providers)\n"
+		"  -m METHOD\tMethod to use to set color temperature\n"
+		"  \t\t(Type `list' to see available methods)\n"
+		"  -o\t\tOne shot mode (do not continuously adjust"
+		" color temperature)\n"
+		"  -O TEMP\tOne shot manual mode (set color temperature)\n"
+		"  -p\t\tPrint mode (only print parameters and exit)\n"
+		"  -x\t\tReset mode (remove adjustment from screen)\n"
+		"  -r\t\tDisable fading between color temperatures\n"
+		"  -t DAY:NIGHT\tColor temperature to set at daytime/night\n"),
+	      stdout);
+	fputs("\n", stdout);
+
+	/* TRANSLATORS: help output 5 */
+	printf(_("The neutral temperature is %uK. Using this value will not change "
+		 "the color\ntemperature of the display. Setting the color temperature "
+		 "to a value higher\nthan this results in more blue light, and setting "
+		 "a lower value will result in\nmore red light.\n"),
+		 NEUTRAL_TEMP);
+
+	fputs("\n", stdout);
+
+	/* TRANSLATORS: help output 6 */
+	printf(_("Default values:\n\n"
+		 "  Daytime temperature: %uK\n"
+		 "  Night temperature: %uK\n"),
+	       DEFAULT_DAY_TEMP, DEFAULT_NIGHT_TEMP);
+
+	fputs("\n", stdout);
+
+	/* TRANSLATORS: help output 7 */
+	printf(_("Please report bugs to <%s>\n"), PACKAGE_BUGREPORT);
+}
+
+/* Print list of adjustment methods. */
+static void
+print_method_list(const gamma_method_t *gamma_methods)
+{
+	fputs(_("Available adjustment methods:\n"), stdout);
+	for (int i = 0; gamma_methods[i].name != NULL; i++) {
+		printf("  %s\n", gamma_methods[i].name);
+	}
+
+	fputs("\n", stdout);
+	fputs(_("Specify colon-separated options with"
+		" `-m METHOD:OPTIONS'.\n"), stdout);
+	/* TRANSLATORS: `help' must not be translated. */
+	fputs(_("Try `-m METHOD:help' for help.\n"), stdout);
+}
+
+/* Print list of location providers. */
+static void
+print_provider_list(const location_provider_t location_providers[])
+{
+	fputs(_("Available location providers:\n"), stdout);
+	for (int i = 0; location_providers[i].name != NULL; i++) {
+		printf("  %s\n", location_providers[i].name);
+	}
+
+	fputs("\n", stdout);
+	fputs(_("Specify colon-separated options with"
+		"`-l PROVIDER:OPTIONS'.\n"), stdout);
+	/* TRANSLATORS: `help' must not be translated. */
+	fputs(_("Try `-l PROVIDER:help' for help.\n"), stdout);
+}
+
+/* Return the gamma method with the given name. */
+static const gamma_method_t *
+find_gamma_method(const gamma_method_t gamma_methods[], const char *name)
+{
+	const gamma_method_t *method = NULL;
+	for (int i = 0; gamma_methods[i].name != NULL; i++) {
+		const gamma_method_t *m = &gamma_methods[i];
+		if (strcasecmp(name, m->name) == 0) {
+			method = m;
+			break;
+		}
+	}
+
+	return method;
+}
+
+/* Return location provider with the given name. */
+static const location_provider_t *
+find_location_provider(
+	const location_provider_t location_providers[], const char *name)
+{
+	const location_provider_t *provider = NULL;
+	for (int i = 0; location_providers[i].name != NULL; i++) {
+		const location_provider_t *p = &location_providers[i];
+		if (strcasecmp(name, p->name) == 0) {
+			provider = p;
+			break;
+		}
+	}
+
+	return provider;
+}
+
+
+/* Initialize options struct. */
+void
+options_init(options_t *options)
+{
+	options->config_filepath = NULL;
+
+	/* Default elevation values. */
+	options->scheme.high = TRANSITION_HIGH;
+	options->scheme.low = TRANSITION_LOW;
+
+	/* Settings for day, night and transition period.
+	   Initialized to indicate that the values are not set yet. */
+	options->scheme.use_time = 0;
+	options->scheme.dawn.start = -1;
+	options->scheme.dawn.end = -1;
+	options->scheme.dusk.start = -1;
+	options->scheme.dusk.end = -1;
+
+	options->scheme.day.temperature = -1;
+	options->scheme.day.gamma[0] = NAN;
+	options->scheme.day.brightness = NAN;
+
+	options->scheme.night.temperature = -1;
+	options->scheme.night.gamma[0] = NAN;
+	options->scheme.night.brightness = NAN;
+
+	/* Temperature for manual mode */
+	options->temp_set = -1;
+
+	options->method = NULL;
+	options->method_args = NULL;
+
+	options->provider = NULL;
+	options->provider_args = NULL;
+
+	options->use_fade = -1;
+	options->mode = PROGRAM_MODE_CONTINUAL;
+	options->verbose = 0;
+}
+
+/* Parse command line arguments. */
+void
+options_parse_args(
+	options_t *options, int argc, char *argv[],
+	const gamma_method_t *gamma_methods,
+	const location_provider_t *location_providers)
+{
+	int r;
+	char *s;
+
+	/* Parse command line arguments. */
+	int opt;
+	while ((opt = getopt(argc, argv, "b:c:g:hl:m:oO:prt:vVx")) != -1) {
+		switch (opt) {
+		case 'b':
+			parse_brightness_string(
+				optarg,
+				&options->scheme.day.brightness,
+				&options->scheme.night.brightness);
+			break;
+		case 'c':
+			free(options->config_filepath);
+			options->config_filepath = strdup(optarg);
+			break;
+		case 'g':
+			r = parse_gamma_string(
+				optarg, options->scheme.day.gamma);
+			if (r < 0) {
+				fputs(_("Malformed gamma argument.\n"),
+				      stderr);
+				fputs(_("Try `-h' for more"
+					" information.\n"), stderr);
+				exit(EXIT_FAILURE);
+			}
+
+			/* Set night gamma to the same value as day gamma.
+			   To set these to distinct values use the config
+			   file. */
+			memcpy(options->scheme.night.gamma,
+			       options->scheme.day.gamma,
+			       sizeof(options->scheme.night.gamma));
+			break;
+		case 'h':
+			print_help(argv[0]);
+			exit(EXIT_SUCCESS);
+			break;
+		case 'l':
+			/* Print list of providers if argument is `list' */
+			if (strcasecmp(optarg, "list") == 0) {
+				print_provider_list(location_providers);
+				exit(EXIT_SUCCESS);
+			}
+
+			char *provider_name = NULL;
+
+			/* Don't save the result of strtof(); we simply want
+			   to know if optarg can be parsed as a float. */
+			errno = 0;
+			char *end;
+			strtof(optarg, &end);
+			if (errno == 0 && *end == ':') {
+				/* Use instead as arguments to `manual'. */
+				provider_name = "manual";
+				options->provider_args = optarg;
+			} else {
+				/* Split off provider arguments. */
+				s = strchr(optarg, ':');
+				if (s != NULL) {
+					*(s++) = '\0';
+					options->provider_args = s;
+				}
+
+				provider_name = optarg;
+			}
+
+			/* Lookup provider from name. */
+			options->provider = find_location_provider(
+				location_providers, provider_name);
+			if (options->provider == NULL) {
+				fprintf(stderr, _("Unknown location provider"
+						  " `%s'.\n"), provider_name);
+				exit(EXIT_FAILURE);
+			}
+
+			/* Print provider help if arg is `help'. */
+			if (options->provider_args != NULL &&
+			    strcasecmp(options->provider_args, "help") == 0) {
+				options->provider->print_help(stdout);
+				exit(EXIT_SUCCESS);
+			}
+			break;
+		case 'm':
+			/* Print list of methods if argument is `list' */
+			if (strcasecmp(optarg, "list") == 0) {
+				print_method_list(gamma_methods);
+				exit(EXIT_SUCCESS);
+			}
+
+			/* Split off method arguments. */
+			s = strchr(optarg, ':');
+			if (s != NULL) {
+				*(s++) = '\0';
+				options->method_args = s;
+			}
+
+			/* Find adjustment method by name. */
+			options->method = find_gamma_method(
+				gamma_methods, optarg);
+			if (options->method == NULL) {
+				/* TRANSLATORS: This refers to the method
+				   used to adjust colors e.g VidMode */
+				fprintf(stderr, _("Unknown adjustment method"
+						  " `%s'.\n"), optarg);
+				exit(EXIT_FAILURE);
+			}
+
+			/* Print method help if arg is `help'. */
+			if (options->method_args != NULL &&
+			    strcasecmp(options->method_args, "help") == 0) {
+				options->method->print_help(stdout);
+				exit(EXIT_SUCCESS);
+			}
+			break;
+		case 'o':
+			options->mode = PROGRAM_MODE_ONE_SHOT;
+			break;
+		case 'O':
+			options->mode = PROGRAM_MODE_MANUAL;
+			options->temp_set = atoi(optarg);
+			break;
+		case 'p':
+			options->mode = PROGRAM_MODE_PRINT;
+			break;
+		case 'r':
+			options->use_fade = 0;
+			break;
+		case 't':
+			s = strchr(optarg, ':');
+			if (s == NULL) {
+				fputs(_("Malformed temperature argument.\n"),
+				      stderr);
+				fputs(_("Try `-h' for more information.\n"),
+				      stderr);
+				exit(EXIT_FAILURE);
+			}
+			*(s++) = '\0';
+			options->scheme.day.temperature = atoi(optarg);
+			options->scheme.night.temperature = atoi(s);
+			break;
+		case 'v':
+			options->verbose = 1;
+			break;
+		case 'V':
+			printf("%s\n", PACKAGE_STRING);
+			exit(EXIT_SUCCESS);
+			break;
+		case 'x':
+			options->mode = PROGRAM_MODE_RESET;
+			break;
+		case '?':
+			fputs(_("Try `-h' for more information.\n"), stderr);
+			exit(EXIT_FAILURE);
+			break;
+		}
+	}
+}
+
+/* Parse options defined in the config file. */
+void
+options_parse_config_file(
+	options_t *options, config_ini_state_t *config_state,
+	const gamma_method_t *gamma_methods,
+	const location_provider_t *location_providers)
+{
+	int r;
+
+	/* Read global config settings. */
+	config_ini_section_t *section = config_ini_get_section(
+		config_state, "redshift");
+	if (section == NULL) return;
+
+	config_ini_setting_t *setting = section->settings;
+	while (setting != NULL) {
+		if (strcasecmp(setting->name, "temp-day") == 0) {
+			if (options->scheme.day.temperature < 0) {
+				options->scheme.day.temperature =
+					atoi(setting->value);
+			}
+		} else if (strcasecmp(setting->name, "temp-night") == 0) {
+			if (options->scheme.night.temperature < 0) {
+				options->scheme.night.temperature =
+					atoi(setting->value);
+			}
+		} else if (strcasecmp(setting->name, "transition") == 0 ||
+			   strcasecmp(setting->name, "fade") == 0) {
+			/* "fade" is preferred, "transition" is
+			   deprecated as the setting key. */
+			if (options->use_fade < 0) {
+				options->use_fade = !!atoi(setting->value);
+			}
+		} else if (strcasecmp(setting->name, "brightness") == 0) {
+			if (isnan(options->scheme.day.brightness)) {
+				options->scheme.day.brightness =
+					atof(setting->value);
+			}
+			if (isnan(options->scheme.night.brightness)) {
+				options->scheme.night.brightness =
+					atof(setting->value);
+			}
+		} else if (strcasecmp(setting->name, "brightness-day") == 0) {
+			if (isnan(options->scheme.day.brightness)) {
+				options->scheme.day.brightness =
+					atof(setting->value);
+			}
+		} else if (strcasecmp(setting->name,
+			              "brightness-night") == 0) {
+			if (isnan(options->scheme.night.brightness)) {
+				options->scheme.night.brightness =
+					atof(setting->value);
+			}
+		} else if (strcasecmp(setting->name, "elevation-high") == 0) {
+			options->scheme.high = atof(setting->value);
+		} else if (strcasecmp(setting->name, "elevation-low") == 0) {
+			options->scheme.low = atof(setting->value);
+		} else if (strcasecmp(setting->name, "gamma") == 0) {
+			if (isnan(options->scheme.day.gamma[0])) {
+				r = parse_gamma_string(
+					setting->value,
+					options->scheme.day.gamma);
+				if (r < 0) {
+					fputs(_("Malformed gamma setting.\n"),
+					      stderr);
+					exit(EXIT_FAILURE);
+				}
+				memcpy(options->scheme.night.gamma,
+				       options->scheme.day.gamma,
+				       sizeof(options->scheme.night.gamma));
+			}
+		} else if (strcasecmp(setting->name, "gamma-day") == 0) {
+			if (isnan(options->scheme.day.gamma[0])) {
+				r = parse_gamma_string(
+					setting->value,
+					options->scheme.day.gamma);
+				if (r < 0) {
+					fputs(_("Malformed gamma setting.\n"),
+					      stderr);
+					exit(EXIT_FAILURE);
+				}
+			}
+		} else if (strcasecmp(setting->name, "gamma-night") == 0) {
+			if (isnan(options->scheme.night.gamma[0])) {
+				r = parse_gamma_string(
+					setting->value,
+					options->scheme.night.gamma);
+				if (r < 0) {
+					fputs(_("Malformed gamma setting.\n"),
+					      stderr);
+					exit(EXIT_FAILURE);
+				}
+			}
+		} else if (strcasecmp(setting->name,
+				      "adjustment-method") == 0) {
+			if (options->method == NULL) {
+				options->method = find_gamma_method(
+					gamma_methods, setting->value);
+				if (options->method == NULL) {
+					fprintf(stderr, _("Unknown adjustment"
+							  " method `%s'.\n"),
+						setting->value);
+					exit(EXIT_FAILURE);
+				}
+			}
+		} else if (strcasecmp(setting->name,
+				      "location-provider") == 0) {
+			if (options->provider == NULL) {
+				options->provider = find_location_provider(
+					location_providers,
+					setting->value);
+				if (options->provider == NULL) {
+					fprintf(stderr, _("Unknown location"
+							  " provider `%s'.\n"),
+						setting->value);
+					exit(EXIT_FAILURE);
+				}
+			}
+		} else if (strcasecmp(setting->name, "dawn-time") == 0) {
+			if (options->scheme.dawn.start < 0) {
+				int r = parse_transition_range(
+					setting->value, &options->scheme.dawn);
+				if (r < 0) {
+					fprintf(stderr, _("Malformed dawn-time"
+							  " setting `%s'.\n"),
+						setting->value);
+					exit(EXIT_FAILURE);
+				}
+			}
+		} else if (strcasecmp(setting->name, "dusk-time") == 0) {
+			if (options->scheme.dusk.start < 0) {
+				int r = parse_transition_range(
+					setting->value, &options->scheme.dusk);
+				if (r < 0) {
+					fprintf(stderr, _("Malformed dusk-time"
+							  " setting `%s'.\n"),
+						setting->value);
+					exit(EXIT_FAILURE);
+				}
+			}
+		} else {
+			fprintf(stderr, _("Unknown configuration"
+					  " setting `%s'.\n"),
+				setting->name);
+		}
+
+		setting = setting->next;
+	}
+}
+
+/* Replace unspecified options with default values. */
+void
+options_set_defaults(options_t *options)
+{
+	if (options->scheme.day.temperature < 0) {
+		options->scheme.day.temperature = DEFAULT_DAY_TEMP;
+	}
+	if (options->scheme.night.temperature < 0) {
+		options->scheme.night.temperature = DEFAULT_NIGHT_TEMP;
+	}
+
+	if (isnan(options->scheme.day.brightness)) {
+		options->scheme.day.brightness = DEFAULT_BRIGHTNESS;
+	}
+	if (isnan(options->scheme.night.brightness)) {
+		options->scheme.night.brightness = DEFAULT_BRIGHTNESS;
+	}
+
+	if (isnan(options->scheme.day.gamma[0])) {
+		options->scheme.day.gamma[0] = DEFAULT_GAMMA;
+		options->scheme.day.gamma[1] = DEFAULT_GAMMA;
+		options->scheme.day.gamma[2] = DEFAULT_GAMMA;
+	}
+	if (isnan(options->scheme.night.gamma[0])) {
+		options->scheme.night.gamma[0] = DEFAULT_GAMMA;
+		options->scheme.night.gamma[1] = DEFAULT_GAMMA;
+		options->scheme.night.gamma[2] = DEFAULT_GAMMA;
+	}
+
+	if (options->use_fade < 0) options->use_fade = 1;
+}

--- a/src/options.h
+++ b/src/options.h
@@ -1,0 +1,61 @@
+/* options.h -- Program options header
+   This file is part of Redshift.
+
+   Redshift is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   Redshift is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with Redshift.  If not, see <http://www.gnu.org/licenses/>.
+
+   Copyright (c) 2017  Jon Lund Steffensen <jonlst@gmail.com>
+*/
+
+#ifndef REDSHIFT_OPTIONS_H
+#define REDSHIFT_OPTIONS_H
+
+#include "redshift.h"
+
+typedef struct {
+	/* Path to config file */
+	char *config_filepath;
+
+	transition_scheme_t scheme;
+	program_mode_t mode;
+	int verbose;
+
+	/* Temperature to set in manual mode. */
+	int temp_set;
+	/* Whether to fade between large skips in color temperature. */
+	int use_fade;
+
+	/* Selected gamma method. */
+	const gamma_method_t *method;
+	/* Arguments for gamma method. */
+	char *method_args;
+
+	/* Selected location provider. */
+	const location_provider_t *provider;
+	/* Arguments for location provider. */
+	char *provider_args;
+} options_t;
+
+
+void options_init(options_t *options);
+void options_parse_args(
+	options_t *options, int argc, char *argv[],
+	const gamma_method_t *gamma_methods,
+	const location_provider_t *location_providers);
+void options_parse_config_file(
+	options_t *options, config_ini_state_t *config_state,
+	const gamma_method_t *gamma_methods,
+	const location_provider_t *location_providers);
+void options_set_defaults(options_t *options);
+
+#endif /* ! REDSHIFT_OPTIONS_H */

--- a/src/redshift.c
+++ b/src/redshift.c
@@ -64,6 +64,7 @@ int poll(struct pollfd *fds, int nfds, int timeout) { abort(); return -1; }
 #include "systemtime.h"
 #include "hooks.h"
 #include "signals.h"
+#include "options.h"
 
 /* pause() is not defined on windows platform but is not needed either.
    Use a noop macro instead. */
@@ -120,22 +121,6 @@ int poll(struct pollfd *fds, int nfds, int timeout) { abort(); return -1; }
 #define MIN_GAMMA   0.1
 #define MAX_GAMMA  10.0
 
-/* Default values for parameters. */
-#define DEFAULT_DAY_TEMP    6500
-#define DEFAULT_NIGHT_TEMP  4500
-#define DEFAULT_BRIGHTNESS   1.0
-#define DEFAULT_GAMMA        1.0
-
-/* The color temperature when no adjustment is applied. */
-#define NEUTRAL_TEMP  6500
-
-/* Angular elevation of the sun at which the color temperature
-   transition period starts and ends (in degress).
-   Transition during twilight, and while the sun is lower than
-   3.0 degrees above the horizon. */
-#define TRANSITION_LOW     SOLAR_CIVIL_TWILIGHT_ELEV
-#define TRANSITION_HIGH    3.0
-
 /* Duration of sleep between screen updates (milliseconds). */
 #define SLEEP_DURATION        5000
 #define SLEEP_DURATION_SHORT  100
@@ -143,34 +128,6 @@ int poll(struct pollfd *fds, int nfds, int timeout) { abort(); return -1; }
 /* Length of fade in numbers of short sleep durations. */
 #define FADE_LENGTH  40
 
-/* Program modes. */
-typedef enum {
-	PROGRAM_MODE_CONTINUAL,
-	PROGRAM_MODE_ONE_SHOT,
-	PROGRAM_MODE_PRINT,
-	PROGRAM_MODE_RESET,
-	PROGRAM_MODE_MANUAL
-} program_mode_t;
-
-/* Time range.
-   Fields are offsets from midnight in seconds. */
-typedef struct {
-	int start;
-	int end;
-} time_range_t;
-
-/* Transition scheme.
-   The solar elevations at which the transition begins/ends,
-   and the association color settings. */
-typedef struct {
-	double high;
-	double low;
-	int use_time; /* When enabled, ignore elevation and use time ranges. */
-	time_range_t dawn;
-	time_range_t dusk;
-	color_setting_t day;
-	color_setting_t night;
-} transition_scheme_t;
 
 /* Names of periods of day */
 static const char *period_names[] = {
@@ -345,105 +302,6 @@ color_setting_diff_is_major(
 }
 
 
-static void
-print_help(const char *program_name)
-{
-	/* TRANSLATORS: help output 1
-	   LAT is latitude, LON is longitude,
-	   DAY is temperature at daytime,
-	   NIGHT is temperature at night
-	   no-wrap */
-	printf(_("Usage: %s -l LAT:LON -t DAY:NIGHT [OPTIONS...]\n"),
-		program_name);
-	fputs("\n", stdout);
-
-	/* TRANSLATORS: help output 2
-	   no-wrap */
-	fputs(_("Set color temperature of display"
-		" according to time of day.\n"), stdout);
-	fputs("\n", stdout);
-
-	/* TRANSLATORS: help output 3
-	   no-wrap */
-	fputs(_("  -h\t\tDisplay this help message\n"
-		"  -v\t\tVerbose output\n"
-		"  -V\t\tShow program version\n"), stdout);
-	fputs("\n", stdout);
-
-	/* TRANSLATORS: help output 4
-	   `list' must not be translated
-	   no-wrap */
-	fputs(_("  -b DAY:NIGHT\tScreen brightness to apply (between 0.1 and 1.0)\n"
-		"  -c FILE\tLoad settings from specified configuration file\n"
-		"  -g R:G:B\tAdditional gamma correction to apply\n"
-		"  -l LAT:LON\tYour current location\n"
-		"  -l PROVIDER\tSelect provider for automatic"
-		" location updates\n"
-		"  \t\t(Type `list' to see available providers)\n"
-		"  -m METHOD\tMethod to use to set color temperature\n"
-		"  \t\t(Type `list' to see available methods)\n"
-		"  -o\t\tOne shot mode (do not continuously adjust"
-		" color temperature)\n"
-		"  -O TEMP\tOne shot manual mode (set color temperature)\n"
-		"  -p\t\tPrint mode (only print parameters and exit)\n"
-		"  -x\t\tReset mode (remove adjustment from screen)\n"
-		"  -r\t\tDisable fading between color temperatures\n"
-		"  -t DAY:NIGHT\tColor temperature to set at daytime/night\n"),
-	      stdout);
-	fputs("\n", stdout);
-
-	/* TRANSLATORS: help output 5 */
-	printf(_("The neutral temperature is %uK. Using this value will not change "
-		 "the color\ntemperature of the display. Setting the color temperature "
-		 "to a value higher\nthan this results in more blue light, and setting "
-		 "a lower value will result in\nmore red light.\n"),
-		 NEUTRAL_TEMP);
-
-	fputs("\n", stdout);
-
-	/* TRANSLATORS: help output 6 */
-	printf(_("Default values:\n\n"
-		 "  Daytime temperature: %uK\n"
-		 "  Night temperature: %uK\n"),
-	       DEFAULT_DAY_TEMP, DEFAULT_NIGHT_TEMP);
-
-	fputs("\n", stdout);
-
-	/* TRANSLATORS: help output 7 */
-	printf(_("Please report bugs to <%s>\n"), PACKAGE_BUGREPORT);
-}
-
-static void
-print_method_list(const gamma_method_t *gamma_methods)
-{
-	fputs(_("Available adjustment methods:\n"), stdout);
-	for (int i = 0; gamma_methods[i].name != NULL; i++) {
-		printf("  %s\n", gamma_methods[i].name);
-	}
-
-	fputs("\n", stdout);
-	fputs(_("Specify colon-separated options with"
-		" `-m METHOD:OPTIONS'.\n"), stdout);
-	/* TRANSLATORS: `help' must not be translated. */
-	fputs(_("Try `-m METHOD:help' for help.\n"), stdout);
-}
-
-static void
-print_provider_list(const location_provider_t location_providers[])
-{
-	fputs(_("Available location providers:\n"), stdout);
-	for (int i = 0; location_providers[i].name != NULL; i++) {
-		printf("  %s\n", location_providers[i].name);
-	}
-
-	fputs("\n", stdout);
-	fputs(_("Specify colon-separated options with"
-		"`-l PROVIDER:OPTIONS'.\n"), stdout);
-	/* TRANSLATORS: `help' must not be translated. */
-	fputs(_("Try `-l PROVIDER:help' for help.\n"), stdout);
-}
-
-
 static int
 provider_try_start(const location_provider_t *provider,
 		   location_state_t **state, config_ini_state_t *config,
@@ -614,98 +472,6 @@ method_try_start(const gamma_method_t *method,
 	return 0;
 }
 
-/* A gamma string contains either one floating point value,
-   or three values separated by colon. */
-static int
-parse_gamma_string(const char *str, float gamma[])
-{
-	char *s = strchr(str, ':');
-	if (s == NULL) {
-		/* Use value for all channels */
-		float g = atof(str);
-		gamma[0] = gamma[1] = gamma[2] = g;
-	} else {
-		/* Parse separate value for each channel */
-		*(s++) = '\0';
-		char *g_s = s;
-		s = strchr(s, ':');
-		if (s == NULL) return -1;
-
-		*(s++) = '\0';
-		gamma[0] = atof(str); /* Red */
-		gamma[1] = atof(g_s); /* Blue */
-		gamma[2] = atof(s); /* Green */
-	}
-
-	return 0;
-}
-
-/* A brightness string contains either one floating point value,
-   or two values separated by a colon. */
-static void
-parse_brightness_string(const char *str, float *bright_day, float *bright_night)
-{
-	char *s = strchr(str, ':');
-	if (s == NULL) {
-		/* Same value for day and night. */
-		*bright_day = *bright_night = atof(str);
-	} else {
-		*(s++) = '\0';
-		*bright_day = atof(str);
-		*bright_night = atof(s);
-	}
-}
-
-/* Parse transition time string e.g. "04:50". Returns negative on failure,
-   otherwise the parsed time is returned as seconds since midnight. */
-static int
-parse_transition_time(const char *str, const char **end)
-{
-	const char *min = NULL;
-	errno = 0;
-	long hours = strtol(str, (char **)&min, 10);
-	if (errno != 0 || min == str || min[0] != ':' ||
-	    hours < 0 || hours >= 24) {
-		return -1;
-	}
-
-	min += 1;
-	errno = 0;
-	long minutes = strtol(min, (char **)end, 10);
-	if (errno != 0 || *end == min || minutes < 0 || minutes >= 60) {
-		return -1;
-	}
-
-	return minutes * 60 + hours * 3600;
-}
-
-/* Parse transition range string e.g. "04:50-6:20". Returns negative on
-   failure, otherwise zero. Parsed start and end times are returned as seconds
-   since midnight. */
-static int
-parse_transition_range(const char *str, time_range_t *range)
-{
-	const char *next = NULL;
-	int start_time = parse_transition_time(str, &next);
-	if (start_time < 0) return -1;
-
-	int end_time;
-	if (next[0] == '\0') {
-		end_time = start_time;
-	} else if (next[0] == '-') {
-		next += 1;
-		const char *end = NULL;
-		end_time = parse_transition_time(next, &end);
-		if (end_time < 0 || end[0] != '\0') return -1;
-	} else {
-		return -1;
-	}
-
-	range->start = start_time;
-	range->end = end_time;
-
-	return 0;
-}
 
 /* Check whether gamma is within allowed levels. */
 static int
@@ -744,37 +510,6 @@ location_is_valid(const location_t *location)
 	}
 
 	return 1;
-}
-
-static const gamma_method_t *
-find_gamma_method(const gamma_method_t gamma_methods[], const char *name)
-{
-	const gamma_method_t *method = NULL;
-	for (int i = 0; gamma_methods[i].name != NULL; i++) {
-		const gamma_method_t *m = &gamma_methods[i];
-		if (strcasecmp(name, m->name) == 0) {
-			method = m;
-			break;
-		}
-	}
-
-	return method;
-}
-
-static const location_provider_t *
-find_location_provider(
-	const location_provider_t location_providers[], const char *name)
-{
-	const location_provider_t *provider = NULL;
-	for (int i = 0; location_providers[i].name != NULL; i++) {
-		const location_provider_t *p = &location_providers[i];
-		if (strcasecmp(name, p->name) == 0) {
-			provider = p;
-			break;
-		}
-	}
-
-	return provider;
 }
 
 /* Wait for location to become available from provider.
@@ -1156,31 +891,6 @@ main(int argc, char *argv[])
 	textdomain(PACKAGE);
 #endif
 
-	/* Initialize settings to NULL values. */
-	char *config_filepath = NULL;
-
-	/* Settings for day, night and transition period.
-	   Initialized to indicate that the values are not set yet. */
-	transition_scheme_t scheme =
-		{ TRANSITION_HIGH, TRANSITION_LOW };
-
-	scheme.use_time = 0;
-	scheme.dawn.start = -1;
-	scheme.dawn.end = -1;
-	scheme.dusk.start = -1;
-	scheme.dusk.end = -1;
-
-	scheme.day.temperature = -1;
-	scheme.day.gamma[0] = NAN;
-	scheme.day.brightness = NAN;
-
-	scheme.night.temperature = -1;
-	scheme.night.gamma[0] = NAN;
-	scheme.night.brightness = NAN;
-
-	/* Temperature for manual mode */
-	int temp_set = -1;
-
 	/* List of gamma methods. */
 	const gamma_method_t gamma_methods[] = {
 #ifdef ENABLE_DRM
@@ -1202,9 +912,6 @@ main(int argc, char *argv[])
 		{ NULL }
 	};
 
-	const gamma_method_t *method = NULL;
-	char *method_args = NULL;
-
 	/* List of location providers. */
 	const location_provider_t location_providers[] = {
 #ifdef ENABLE_GEOCLUE2
@@ -1217,383 +924,52 @@ main(int argc, char *argv[])
 		{ NULL }
 	};
 
-	const location_provider_t *provider = NULL;
-	char *provider_args = NULL;
-
-	int use_fade = -1;
-	program_mode_t mode = PROGRAM_MODE_CONTINUAL;
-	int verbose = 0;
-	char *s;
-
 	/* Flush messages consistently even if redirected to a pipe or
 	   file.  Change the flush behaviour to line-buffered, without
 	   changing the actual buffers being used. */
 	setvbuf(stdout, NULL, _IOLBF, 0);
 	setvbuf(stderr, NULL, _IOLBF, 0);
 
-	/* Parse command line arguments. */
-	int opt;
-	while ((opt = getopt(argc, argv, "b:c:g:hl:m:oO:prt:vVx")) != -1) {
-		switch (opt) {
-		case 'b':
-			parse_brightness_string(optarg,
-						&scheme.day.brightness,
-						&scheme.night.brightness);
-			break;
-		case 'c':
-			free(config_filepath);
-			config_filepath = strdup(optarg);
-			break;
-		case 'g':
-			r = parse_gamma_string(optarg, scheme.day.gamma);
-			if (r < 0) {
-				fputs(_("Malformed gamma argument.\n"),
-				      stderr);
-				fputs(_("Try `-h' for more"
-					" information.\n"), stderr);
-				exit(EXIT_FAILURE);
-			}
-
-			/* Set night gamma to the same value as day gamma.
-			   To set these to distinct values use the config
-			   file. */
-			memcpy(scheme.night.gamma, scheme.day.gamma,
-			       sizeof(scheme.night.gamma));
-			break;
-		case 'h':
-			print_help(argv[0]);
-			exit(EXIT_SUCCESS);
-			break;
-		case 'l':
-			/* Print list of providers if argument is `list' */
-			if (strcasecmp(optarg, "list") == 0) {
-				print_provider_list(location_providers);
-				exit(EXIT_SUCCESS);
-			}
-
-			char *provider_name = NULL;
-
-			/* Don't save the result of strtof(); we simply want
-			   to know if optarg can be parsed as a float. */
-			errno = 0;
-			char *end;
-			strtof(optarg, &end);
-			if (errno == 0 && *end == ':') {
-				/* Use instead as arguments to `manual'. */
-				provider_name = "manual";
-				provider_args = optarg;
-			} else {
-				/* Split off provider arguments. */
-				s = strchr(optarg, ':');
-				if (s != NULL) {
-					*(s++) = '\0';
-					provider_args = s;
-				}
-
-				provider_name = optarg;
-			}
-
-			/* Lookup provider from name. */
-			provider = find_location_provider(
-				location_providers, provider_name);
-			if (provider == NULL) {
-				fprintf(stderr, _("Unknown location provider"
-						  " `%s'.\n"), provider_name);
-				exit(EXIT_FAILURE);
-			}
-
-			/* Print provider help if arg is `help'. */
-			if (provider_args != NULL &&
-			    strcasecmp(provider_args, "help") == 0) {
-				provider->print_help(stdout);
-				exit(EXIT_SUCCESS);
-			}
-			break;
-		case 'm':
-			/* Print list of methods if argument is `list' */
-			if (strcasecmp(optarg, "list") == 0) {
-				print_method_list(gamma_methods);
-				exit(EXIT_SUCCESS);
-			}
-
-			/* Split off method arguments. */
-			s = strchr(optarg, ':');
-			if (s != NULL) {
-				*(s++) = '\0';
-				method_args = s;
-			}
-
-			/* Find adjustment method by name. */
-			method = find_gamma_method(gamma_methods, optarg);
-			if (method == NULL) {
-				/* TRANSLATORS: This refers to the method
-				   used to adjust colors e.g VidMode */
-				fprintf(stderr, _("Unknown adjustment method"
-						  " `%s'.\n"), optarg);
-				exit(EXIT_FAILURE);
-			}
-
-			/* Print method help if arg is `help'. */
-			if (method_args != NULL &&
-			    strcasecmp(method_args, "help") == 0) {
-				method->print_help(stdout);
-				exit(EXIT_SUCCESS);
-			}
-			break;
-		case 'o':
-			mode = PROGRAM_MODE_ONE_SHOT;
-			break;
-		case 'O':
-			mode = PROGRAM_MODE_MANUAL;
-			temp_set = atoi(optarg);
-			break;
-		case 'p':
-			mode = PROGRAM_MODE_PRINT;
-			break;
-		case 'r':
-			use_fade = 0;
-			break;
-		case 't':
-			s = strchr(optarg, ':');
-			if (s == NULL) {
-				fputs(_("Malformed temperature argument.\n"),
-				      stderr);
-				fputs(_("Try `-h' for more information.\n"),
-				      stderr);
-				exit(EXIT_FAILURE);
-			}
-			*(s++) = '\0';
-			scheme.day.temperature = atoi(optarg);
-			scheme.night.temperature = atoi(s);
-			break;
-		case 'v':
-			verbose = 1;
-			break;
-                case 'V':
-                        printf("%s\n", PACKAGE_STRING);
-                        exit(EXIT_SUCCESS);
-                        break;
-		case 'x':
-			mode = PROGRAM_MODE_RESET;
-			break;
-		case '?':
-			fputs(_("Try `-h' for more information.\n"), stderr);
-			exit(EXIT_FAILURE);
-			break;
-		}
-	}
+	options_t options;
+	options_init(&options);
+	options_parse_args(
+		&options, argc, argv, gamma_methods, location_providers);
 
 	/* Load settings from config file. */
 	config_ini_state_t config_state;
-	r = config_ini_init(&config_state, config_filepath);
+	r = config_ini_init(&config_state, options.config_filepath);
 	if (r < 0) {
 		fputs("Unable to load config file.\n", stderr);
 		exit(EXIT_FAILURE);
 	}
 
-	free(config_filepath);
+	free(options.config_filepath);
 
-	/* Read global config settings. */
-	config_ini_section_t *section = config_ini_get_section(&config_state,
-							       "redshift");
-	if (section != NULL) {
-		config_ini_setting_t *setting = section->settings;
-		while (setting != NULL) {
-			if (strcasecmp(setting->name, "temp-day") == 0) {
-				if (scheme.day.temperature < 0) {
-					scheme.day.temperature =
-						atoi(setting->value);
-				}
-			} else if (strcasecmp(setting->name,
-					      "temp-night") == 0) {
-				if (scheme.night.temperature < 0) {
-					scheme.night.temperature =
-						atoi(setting->value);
-				}
-			} else if (strcasecmp(
-					setting->name, "transition") == 0 ||
-				   strcasecmp(setting->name, "fade") == 0) {
-				/* "fade" is preferred, "transition" is
-				   deprecated as the setting key. */
-				if (use_fade < 0) {
-					use_fade = !!atoi(setting->value);
-				}
-			} else if (strcasecmp(setting->name,
-					      "brightness") == 0) {
-				if (isnan(scheme.day.brightness)) {
-					scheme.day.brightness =
-						atof(setting->value);
-				}
-				if (isnan(scheme.night.brightness)) {
-					scheme.night.brightness =
-						atof(setting->value);
-				}
-			} else if (strcasecmp(setting->name,
-					      "brightness-day") == 0) {
-				if (isnan(scheme.day.brightness)) {
-					scheme.day.brightness =
-						atof(setting->value);
-				}
-			} else if (strcasecmp(setting->name,
-					      "brightness-night") == 0) {
-				if (isnan(scheme.night.brightness)) {
-					scheme.night.brightness =
-						atof(setting->value);
-				}
-			} else if (strcasecmp(setting->name,
-					      "elevation-high") == 0) {
-				scheme.high = atof(setting->value);
-			} else if (strcasecmp(setting->name,
-					      "elevation-low") == 0) {
-				scheme.low = atof(setting->value);
-			} else if (strcasecmp(setting->name, "gamma") == 0) {
-				if (isnan(scheme.day.gamma[0])) {
-					r = parse_gamma_string(setting->value,
-							       scheme.day.gamma);
-					if (r < 0) {
-						fputs(_("Malformed gamma"
-							" setting.\n"),
-						      stderr);
-						exit(EXIT_FAILURE);
-					}
-					memcpy(scheme.night.gamma, scheme.day.gamma,
-					       sizeof(scheme.night.gamma));
-				}
-			} else if (strcasecmp(setting->name, "gamma-day") == 0) {
-				if (isnan(scheme.day.gamma[0])) {
-					r = parse_gamma_string(setting->value,
-							       scheme.day.gamma);
-					if (r < 0) {
-						fputs(_("Malformed gamma"
-							" setting.\n"),
-						      stderr);
-						exit(EXIT_FAILURE);
-					}
-				}
-			} else if (strcasecmp(setting->name, "gamma-night") == 0) {
-				if (isnan(scheme.night.gamma[0])) {
-					r = parse_gamma_string(setting->value,
-							       scheme.night.gamma);
-					if (r < 0) {
-						fputs(_("Malformed gamma"
-							" setting.\n"),
-						      stderr);
-						exit(EXIT_FAILURE);
-					}
-				}
-			} else if (strcasecmp(setting->name,
-					      "adjustment-method") == 0) {
-				if (method == NULL) {
-					method = find_gamma_method(
-						gamma_methods, setting->value);
-					if (method == NULL) {
-						fprintf(stderr, _("Unknown"
-								  " adjustment"
-								  " method"
-								  " `%s'.\n"),
-							setting->value);
-						exit(EXIT_FAILURE);
-					}
-				}
-			} else if (strcasecmp(setting->name,
-					      "location-provider") == 0) {
-				if (provider == NULL) {
-					provider = find_location_provider(
-						location_providers,
-						setting->value);
-					if (provider == NULL) {
-						fprintf(stderr, _("Unknown"
-								  " location"
-								  " provider"
-								  " `%s'.\n"),
-							setting->value);
-						exit(EXIT_FAILURE);
-					}
-				}
-			} else if (strcasecmp(setting->name,
-					      "dawn-time") == 0) {
-				if (scheme.dawn.start < 0) {
-					int r = parse_transition_range(
-						setting->value, &scheme.dawn);
-					if (r < 0) {
-						fprintf(stderr, _("Malformed"
-								  " dawn-time"
-								  " setting"
-								  " `%s'.\n"),
-							setting->value);
-						exit(EXIT_FAILURE);
-					}
-				}
-			} else if (strcasecmp(setting->name,
-					      "dusk-time") == 0) {
-				if (scheme.dusk.start < 0) {
-					int r = parse_transition_range(
-						setting->value, &scheme.dusk);
-					if (r < 0) {
-						fprintf(stderr, _("Malformed"
-								  " dusk-time"
-								  " setting"
-								  " `%s'.\n"),
-							setting->value);
-						exit(EXIT_FAILURE);
-					}
-				}
-			} else {
-				fprintf(stderr, _("Unknown configuration"
-						  " setting `%s'.\n"),
-					setting->name);
-			}
-			setting = setting->next;
-		}
-	}
+	options_parse_config_file(
+		&options, &config_state, gamma_methods, location_providers);
 
-	/* Use default values for settings that were neither defined in
-	   the config file nor on the command line. */
-	if (scheme.day.temperature < 0) {
-		scheme.day.temperature = DEFAULT_DAY_TEMP;
-	}
-	if (scheme.night.temperature < 0) {
-		scheme.night.temperature = DEFAULT_NIGHT_TEMP;
-	}
+	options_set_defaults(&options);
 
-	if (isnan(scheme.day.brightness)) {
-		scheme.day.brightness = DEFAULT_BRIGHTNESS;
-	}
-	if (isnan(scheme.night.brightness)) {
-		scheme.night.brightness = DEFAULT_BRIGHTNESS;
-	}
-
-	if (isnan(scheme.day.gamma[0])) {
-		scheme.day.gamma[0] = DEFAULT_GAMMA;
-		scheme.day.gamma[1] = DEFAULT_GAMMA;
-		scheme.day.gamma[2] = DEFAULT_GAMMA;
-	}
-	if (isnan(scheme.night.gamma[0])) {
-		scheme.night.gamma[0] = DEFAULT_GAMMA;
-		scheme.night.gamma[1] = DEFAULT_GAMMA;
-		scheme.night.gamma[2] = DEFAULT_GAMMA;
-	}
-
-	if (use_fade < 0) use_fade = 1;
-
-	if (scheme.dawn.start >= 0 || scheme.dawn.end >= 0 ||
-	    scheme.dusk.start >= 0 || scheme.dusk.end >= 0) {
-		if (scheme.dawn.start < 0 || scheme.dawn.end < 0 ||
-		    scheme.dusk.start < 0 || scheme.dusk.end < 0) {
+	if (options.scheme.dawn.start >= 0 || options.scheme.dawn.end >= 0 ||
+	    options.scheme.dusk.start >= 0 || options.scheme.dusk.end >= 0) {
+		if (options.scheme.dawn.start < 0 ||
+		    options.scheme.dawn.end < 0 ||
+		    options.scheme.dusk.start < 0 ||
+		    options.scheme.dusk.end < 0) {
 			fputs(_("Partitial time-configuration not"
 				" supported!\n"), stderr);
 			exit(EXIT_FAILURE);
 		}
 
-		if (scheme.dawn.start > scheme.dawn.end ||
-		    scheme.dawn.end > scheme.dusk.start ||
-		    scheme.dusk.start > scheme.dusk.end) {
+		if (options.scheme.dawn.start > options.scheme.dawn.end ||
+		    options.scheme.dawn.end > options.scheme.dusk.start ||
+		    options.scheme.dusk.start > options.scheme.dusk.end) {
 			fputs(_("Invalid dawn/dusk time configuration!\n"),
 			      stderr);
 			exit(EXIT_FAILURE);
 		}
 
-		scheme.use_time = 1;
+		options.scheme.use_time = 1;
 	}
 
 	/* Initialize location provider if needed. If provider is NULL
@@ -1602,14 +978,15 @@ main(int argc, char *argv[])
 
 	/* Location is not needed for reset mode and manual mode. */
 	int need_location =
-		mode != PROGRAM_MODE_RESET &&
-		mode != PROGRAM_MODE_MANUAL &&
-		!scheme.use_time;
+		options.mode != PROGRAM_MODE_RESET &&
+		options.mode != PROGRAM_MODE_MANUAL &&
+		!options.scheme.use_time;
 	if (need_location) {
-		if (provider != NULL) {
+		if (options.provider != NULL) {
 			/* Use provider specified on command line. */
-			r = provider_try_start(provider, &location_state,
-					       &config_state, provider_args);
+			r = provider_try_start(
+				options.provider, &location_state,
+				&config_state, options.provider_args);
 			if (r < 0) exit(EXIT_FAILURE);
 		} else {
 			/* Try all providers, use the first that works. */
@@ -1630,13 +1007,13 @@ main(int argc, char *argv[])
 
 				/* Found provider that works. */
 				printf(_("Using provider `%s'.\n"), p->name);
-				provider = p;
+				options.provider = p;
 				break;
 			}
 
 			/* Failure if no providers were successful at this
 			   point. */
-			if (provider == NULL) {
+			if (options.provider == NULL) {
 				fputs(_("No more location providers"
 					" to try.\n"), stderr);
 				exit(EXIT_FAILURE);
@@ -1644,33 +1021,33 @@ main(int argc, char *argv[])
 		}
 
 		/* Solar elevations */
-		if (scheme.high < scheme.low) {
+		if (options.scheme.high < options.scheme.low) {
 			fprintf(stderr,
 				_("High transition elevation cannot be lower than"
 				  " the low transition elevation.\n"));
 			exit(EXIT_FAILURE);
 		}
 
-		if (verbose) {
+		if (options.verbose) {
 			/* TRANSLATORS: Append degree symbols if possible. */
 			printf(_("Solar elevations: day above %.1f, night below %.1f\n"),
-			       scheme.high, scheme.low);
+			       options.scheme.high, options.scheme.low);
 		}
 	}
 
-	if (mode != PROGRAM_MODE_RESET &&
-	    mode != PROGRAM_MODE_MANUAL) {
-		if (verbose) {
+	if (options.mode != PROGRAM_MODE_RESET &&
+	    options.mode != PROGRAM_MODE_MANUAL) {
+		if (options.verbose) {
 			printf(_("Temperatures: %dK at day, %dK at night\n"),
-			       scheme.day.temperature,
-			       scheme.night.temperature);
+			       options.scheme.day.temperature,
+			       options.scheme.night.temperature);
 		}
 
 		/* Color temperature */
-		if (scheme.day.temperature < MIN_TEMP ||
-		    scheme.day.temperature > MAX_TEMP ||
-		    scheme.night.temperature < MIN_TEMP ||
-		    scheme.night.temperature > MAX_TEMP) {
+		if (options.scheme.day.temperature < MIN_TEMP ||
+		    options.scheme.day.temperature > MAX_TEMP ||
+		    options.scheme.night.temperature < MIN_TEMP ||
+		    options.scheme.night.temperature > MAX_TEMP) {
 			fprintf(stderr,
 				_("Temperature must be between %uK and %uK.\n"),
 				MIN_TEMP, MAX_TEMP);
@@ -1678,9 +1055,10 @@ main(int argc, char *argv[])
 		}
 	}
 
-	if (mode == PROGRAM_MODE_MANUAL) {
+	if (options.mode == PROGRAM_MODE_MANUAL) {
 		/* Check color temperature to be set */
-		if (temp_set < MIN_TEMP || temp_set > MAX_TEMP) {
+		if (options.temp_set < MIN_TEMP ||
+		    options.temp_set > MAX_TEMP) {
 			fprintf(stderr,
 				_("Temperature must be between %uK and %uK.\n"),
 				MIN_TEMP, MAX_TEMP);
@@ -1689,52 +1067,57 @@ main(int argc, char *argv[])
 	}
 
 	/* Brightness */
-	if (scheme.day.brightness < MIN_BRIGHTNESS ||
-	    scheme.day.brightness > MAX_BRIGHTNESS ||
-	    scheme.night.brightness < MIN_BRIGHTNESS ||
-	    scheme.night.brightness > MAX_BRIGHTNESS) {
+	if (options.scheme.day.brightness < MIN_BRIGHTNESS ||
+	    options.scheme.day.brightness > MAX_BRIGHTNESS ||
+	    options.scheme.night.brightness < MIN_BRIGHTNESS ||
+	    options.scheme.night.brightness > MAX_BRIGHTNESS) {
 		fprintf(stderr,
 			_("Brightness values must be between %.1f and %.1f.\n"),
 			MIN_BRIGHTNESS, MAX_BRIGHTNESS);
 		exit(EXIT_FAILURE);
 	}
 
-	if (verbose) {
+	if (options.verbose) {
 		printf(_("Brightness: %.2f:%.2f\n"),
-		       scheme.day.brightness, scheme.night.brightness);
+		       options.scheme.day.brightness,
+		       options.scheme.night.brightness);
 	}
 
 	/* Gamma */
-	if (!gamma_is_valid(scheme.day.gamma) ||
-	    !gamma_is_valid(scheme.night.gamma)) {
+	if (!gamma_is_valid(options.scheme.day.gamma) ||
+	    !gamma_is_valid(options.scheme.night.gamma)) {
 		fprintf(stderr,
 			_("Gamma value must be between %.1f and %.1f.\n"),
 			MIN_GAMMA, MAX_GAMMA);
 		exit(EXIT_FAILURE);
 	}
 
-	if (verbose) {
+	if (options.verbose) {
 		/* TRANSLATORS: The string in parenthesis is either
 		   Daytime or Night (translated). */
 		printf(_("Gamma (%s): %.3f, %.3f, %.3f\n"),
-		       _("Daytime"), scheme.day.gamma[0],
-		       scheme.day.gamma[1], scheme.day.gamma[2]);
+		       _("Daytime"), options.scheme.day.gamma[0],
+		       options.scheme.day.gamma[1],
+		       options.scheme.day.gamma[2]);
 		printf(_("Gamma (%s): %.3f, %.3f, %.3f\n"),
-		       _("Night"), scheme.night.gamma[0],
-		       scheme.night.gamma[1], scheme.night.gamma[2]);
+		       _("Night"), options.scheme.night.gamma[0],
+		       options.scheme.night.gamma[1],
+		       options.scheme.night.gamma[2]);
 	}
+
+	transition_scheme_t *scheme = &options.scheme;
 
 	/* Initialize gamma adjustment method. If method is NULL
 	   try all methods until one that works is found. */
 	gamma_state_t *method_state;
 
 	/* Gamma adjustment not needed for print mode */
-	if (mode != PROGRAM_MODE_PRINT) {
-		if (method != NULL) {
+	if (options.mode != PROGRAM_MODE_PRINT) {
+		if (options.method != NULL) {
 			/* Use method specified on command line. */
 			r = method_try_start(
-				method, &method_state, &config_state,
-				method_args);
+				options.method, &method_state, &config_state,
+				options.method_args);
 			if (r < 0) exit(EXIT_FAILURE);
 		} else {
 			/* Try all methods, use the first that works. */
@@ -1751,12 +1134,12 @@ main(int argc, char *argv[])
 
 				/* Found method that works. */
 				printf(_("Using method `%s'.\n"), m->name);
-				method = m;
+				options.method = m;
 				break;
 			}
 
 			/* Failure if no methods were successful at this point. */
-			if (method == NULL) {
+			if (options.method == NULL) {
 				fputs(_("No more methods to try.\n"), stderr);
 				exit(EXIT_FAILURE);
 			}
@@ -1765,7 +1148,7 @@ main(int argc, char *argv[])
 
 	config_ini_free(&config_state);
 
-	switch (mode) {
+	switch (options.mode) {
 	case PROGRAM_MODE_ONE_SHOT:
 	case PROGRAM_MODE_PRINT:
 	{
@@ -1776,7 +1159,7 @@ main(int argc, char *argv[])
 
 			/* Wait for location provider. */
 			int r = provider_get_location(
-				provider, location_state, -1, &loc);
+				options.provider, location_state, -1, &loc);
 			if (r < 0) {
 				fputs(_("Unable to get location"
 					" from provider.\n"), stderr);
@@ -1794,39 +1177,39 @@ main(int argc, char *argv[])
 		r = systemtime_get_time(&now);
 		if (r < 0) {
 			fputs(_("Unable to read system time.\n"), stderr);
-			method->free(method_state);
+			options.method->free(method_state);
 			exit(EXIT_FAILURE);
 		}
 
 		period_t period;
 		double transition_prog;
-		if (scheme.use_time) {
+		if (options.scheme.use_time) {
 			int time_offset = get_seconds_since_midnight(now);
-			period = get_period_from_time(&scheme, time_offset);
+			period = get_period_from_time(scheme, time_offset);
 			transition_prog = get_transition_progress_from_time(
-				&scheme, time_offset);
+				scheme, time_offset);
 		} else {
 			/* Current angular elevation of the sun */
 			double elevation = solar_elevation(
 				now, loc.lat, loc.lon);
-			if (verbose) {
+			if (options.verbose) {
 				/* TRANSLATORS: Append degree symbol if
 				   possible. */
 				printf(_("Solar elevation: %f\n"), elevation);
 			}
 
-			period = get_period_from_elevation(&scheme, elevation);
+			period = get_period_from_elevation(scheme, elevation);
 			transition_prog =
 				get_transition_progress_from_elevation(
-					&scheme, elevation);
+					scheme, elevation);
 		}
 
 		/* Use transition progress to set color temperature */
 		color_setting_t interp;
 		interpolate_transition_scheme(
-			&scheme, transition_prog, &interp);
+			scheme, transition_prog, &interp);
 
-		if (verbose || mode == PROGRAM_MODE_PRINT) {
+		if (options.verbose || options.mode == PROGRAM_MODE_PRINT) {
 			print_period(period, transition_prog);
 			printf(_("Color temperature: %uK\n"),
 			       interp.temperature);
@@ -1834,13 +1217,14 @@ main(int argc, char *argv[])
 			       interp.brightness);
 		}
 
-		if (mode != PROGRAM_MODE_PRINT) {
+		if (options.mode != PROGRAM_MODE_PRINT) {
 			/* Adjust temperature */
-			r = method->set_temperature(method_state, &interp);
+			r = options.method->set_temperature(
+				method_state, &interp);
 			if (r < 0) {
 				fputs(_("Temperature adjustment failed.\n"),
 				      stderr);
-				method->free(method_state);
+				options.method->free(method_state);
 				exit(EXIT_FAILURE);
 			}
 
@@ -1848,7 +1232,7 @@ main(int argc, char *argv[])
 			   automatically revert when the process exits.
 			   Therefore, we have to loop until CTRL-C is received.
 			   */
-			if (strcmp(method->name, "quartz") == 0) {
+			if (strcmp(options.method->name, "quartz") == 0) {
 				fputs(_("Press ctrl-c to stop...\n"), stderr);
 				pause();
 			}
@@ -1857,22 +1241,25 @@ main(int argc, char *argv[])
 	break;
 	case PROGRAM_MODE_MANUAL:
 	{
-		if (verbose) printf(_("Color temperature: %uK\n"), temp_set);
+		if (options.verbose) {
+			printf(_("Color temperature: %uK\n"),
+			       options.temp_set);
+		}
 
 		/* Adjust temperature */
-		color_setting_t manual = scheme.day;
-		manual.temperature = temp_set;
-		r = method->set_temperature(method_state, &manual);
+		color_setting_t manual = scheme->day;
+		manual.temperature = options.temp_set;
+		r = options.method->set_temperature(method_state, &manual);
 		if (r < 0) {
 			fputs(_("Temperature adjustment failed.\n"), stderr);
-			method->free(method_state);
+			options.method->free(method_state);
 			exit(EXIT_FAILURE);
 		}
 
 		/* In Quartz (OSX) the gamma adjustments will automatically
 		   revert when the process exits. Therefore, we have to loop
 		   until CTRL-C is received. */
-		if (strcmp(method->name, "quartz") == 0) {
+		if (strcmp(options.method->name, "quartz") == 0) {
 			fputs(_("Press ctrl-c to stop...\n"), stderr);
 			pause();
 		}
@@ -1882,17 +1269,17 @@ main(int argc, char *argv[])
 	{
 		/* Reset screen */
 		color_setting_t reset = { NEUTRAL_TEMP, { 1.0, 1.0, 1.0 }, 1.0 };
-		r = method->set_temperature(method_state, &reset);
+		r = options.method->set_temperature(method_state, &reset);
 		if (r < 0) {
 			fputs(_("Temperature adjustment failed.\n"), stderr);
-			method->free(method_state);
+			options.method->free(method_state);
 			exit(EXIT_FAILURE);
 		}
 
 		/* In Quartz (OSX) the gamma adjustments will automatically
 		   revert when the process exits. Therefore, we have to loop
 		   until CTRL-C is received. */
-		if (strcmp(method->name, "quartz") == 0) {
+		if (strcmp(options.method->name, "quartz") == 0) {
 			fputs(_("Press ctrl-c to stop...\n"), stderr);
 			pause();
 		}
@@ -1900,22 +1287,23 @@ main(int argc, char *argv[])
 	break;
 	case PROGRAM_MODE_CONTINUAL:
 	{
-		r = run_continual_mode(provider, location_state, &scheme,
-				       method, method_state,
-				       use_fade, verbose);
+		r = run_continual_mode(
+			options.provider, location_state, scheme,
+			options.method, method_state,
+			options.use_fade, options.verbose);
 		if (r < 0) exit(EXIT_FAILURE);
 	}
 	break;
 	}
 
 	/* Clean up gamma adjustment state */
-	if (mode != PROGRAM_MODE_PRINT) {
-		method->free(method_state);
+	if (options.mode != PROGRAM_MODE_PRINT) {
+		options.method->free(method_state);
 	}
 
 	/* Clean up location provider state */
 	if (need_location) {
-		provider->free(location_state);
+		options.provider->free(location_state);
 	}
 
 	return EXIT_SUCCESS;

--- a/src/redshift.c
+++ b/src/redshift.c
@@ -301,6 +301,17 @@ color_setting_diff_is_major(
 		fabsf(first->gamma[2] - second->gamma[2]) > 0.1);
 }
 
+/* Reset color setting to default values. */
+static void
+color_setting_reset(color_setting_t *color)
+{
+	color->temperature = NEUTRAL_TEMP;
+	color->gamma[0] = 1.0;
+	color->gamma[1] = 1.0;
+	color->gamma[2] = 1.0;
+	color->brightness = 1.0;
+}
+
 
 static int
 provider_try_start(const location_provider_t *provider,
@@ -612,10 +623,11 @@ run_continual_mode(const location_provider_t *provider,
 
 	/* Previous target color setting and current actual color setting.
 	   Actual color setting takes into account the current color fade. */
-	color_setting_t prev_target_interp =
-		{ NEUTRAL_TEMP, { 1.0, 1.0, 1.0 }, 1.0 };
-	color_setting_t interp =
-		{ NEUTRAL_TEMP, { 1.0, 1.0, 1.0 }, 1.0 };
+	color_setting_t prev_target_interp;
+	color_setting_reset(&prev_target_interp);
+
+	color_setting_t interp;
+	color_setting_reset(&interp);
 
 	location_t loc = { NAN, NAN };
 	int need_location = !scheme->use_time;
@@ -711,12 +723,7 @@ run_continual_mode(const location_provider_t *provider,
 			scheme, transition_prog, &target_interp);
 
 		if (disabled) {
-			/* Reset to neutral */
-			target_interp.temperature = NEUTRAL_TEMP;
-			target_interp.brightness = 1.0;
-			target_interp.gamma[0] = 1.0;
-			target_interp.gamma[1] = 1.0;
-			target_interp.gamma[2] = 1.0;
+			color_setting_reset(&target_interp);
 		}
 
 		if (done) {
@@ -1268,7 +1275,9 @@ main(int argc, char *argv[])
 	case PROGRAM_MODE_RESET:
 	{
 		/* Reset screen */
-		color_setting_t reset = { NEUTRAL_TEMP, { 1.0, 1.0, 1.0 }, 1.0 };
+		color_setting_t reset;
+		color_setting_reset(&reset);
+
 		r = options.method->set_temperature(method_state, &reset);
 		if (r < 0) {
 			fputs(_("Temperature adjustment failed.\n"), stderr);

--- a/src/redshift.c
+++ b/src/redshift.c
@@ -127,82 +127,6 @@ typedef union {
 } gamma_state_t;
 
 
-/* Gamma adjustment method structs */
-static const gamma_method_t gamma_methods[] = {
-#ifdef ENABLE_DRM
-	{
-		"drm", 0,
-		(gamma_method_init_func *)drm_init,
-		(gamma_method_start_func *)drm_start,
-		(gamma_method_free_func *)drm_free,
-		(gamma_method_print_help_func *)drm_print_help,
-		(gamma_method_set_option_func *)drm_set_option,
-		(gamma_method_restore_func *)drm_restore,
-		(gamma_method_set_temperature_func *)drm_set_temperature
-	},
-#endif
-#ifdef ENABLE_RANDR
-	{
-		"randr", 1,
-		(gamma_method_init_func *)randr_init,
-		(gamma_method_start_func *)randr_start,
-		(gamma_method_free_func *)randr_free,
-		(gamma_method_print_help_func *)randr_print_help,
-		(gamma_method_set_option_func *)randr_set_option,
-		(gamma_method_restore_func *)randr_restore,
-		(gamma_method_set_temperature_func *)randr_set_temperature
-	},
-#endif
-#ifdef ENABLE_VIDMODE
-	{
-		"vidmode", 1,
-		(gamma_method_init_func *)vidmode_init,
-		(gamma_method_start_func *)vidmode_start,
-		(gamma_method_free_func *)vidmode_free,
-		(gamma_method_print_help_func *)vidmode_print_help,
-		(gamma_method_set_option_func *)vidmode_set_option,
-		(gamma_method_restore_func *)vidmode_restore,
-		(gamma_method_set_temperature_func *)vidmode_set_temperature
-	},
-#endif
-#ifdef ENABLE_QUARTZ
-	{
-		"quartz", 1,
-		(gamma_method_init_func *)quartz_init,
-		(gamma_method_start_func *)quartz_start,
-		(gamma_method_free_func *)quartz_free,
-		(gamma_method_print_help_func *)quartz_print_help,
-		(gamma_method_set_option_func *)quartz_set_option,
-		(gamma_method_restore_func *)quartz_restore,
-		(gamma_method_set_temperature_func *)quartz_set_temperature
-	},
-#endif
-#ifdef ENABLE_WINGDI
-	{
-		"wingdi", 1,
-		(gamma_method_init_func *)w32gdi_init,
-		(gamma_method_start_func *)w32gdi_start,
-		(gamma_method_free_func *)w32gdi_free,
-		(gamma_method_print_help_func *)w32gdi_print_help,
-		(gamma_method_set_option_func *)w32gdi_set_option,
-		(gamma_method_restore_func *)w32gdi_restore,
-		(gamma_method_set_temperature_func *)w32gdi_set_temperature
-	},
-#endif
-	{
-		"dummy", 0,
-		(gamma_method_init_func *)gamma_dummy_init,
-		(gamma_method_start_func *)gamma_dummy_start,
-		(gamma_method_free_func *)gamma_dummy_free,
-		(gamma_method_print_help_func *)gamma_dummy_print_help,
-		(gamma_method_set_option_func *)gamma_dummy_set_option,
-		(gamma_method_restore_func *)gamma_dummy_restore,
-		(gamma_method_set_temperature_func *)gamma_dummy_set_temperature
-	},
-	{ NULL }
-};
-
-
 /* Union of state data for location providers */
 typedef union {
 	location_manual_state_t manual;
@@ -214,51 +138,6 @@ typedef union {
 #endif
 } location_state_t;
 
-
-/* Location provider method structs */
-static const location_provider_t location_providers[] = {
-#ifdef ENABLE_GEOCLUE2
-	{
-		"geoclue2",
-		(location_provider_init_func *)location_geoclue2_init,
-		(location_provider_start_func *)location_geoclue2_start,
-		(location_provider_free_func *)location_geoclue2_free,
-		(location_provider_print_help_func *)
-		location_geoclue2_print_help,
-		(location_provider_set_option_func *)
-		location_geoclue2_set_option,
-		(location_provider_get_fd_func *)location_geoclue2_get_fd,
-		(location_provider_handle_func *)location_geoclue2_handle
-	},
-#endif
-#ifdef ENABLE_CORELOCATION
-	{
-		"corelocation",
-		(location_provider_init_func *)location_corelocation_init,
-		(location_provider_start_func *)location_corelocation_start,
-		(location_provider_free_func *)location_corelocation_free,
-		(location_provider_print_help_func *)
-		location_corelocation_print_help,
-		(location_provider_set_option_func *)
-		location_corelocation_set_option,
-		(location_provider_get_fd_func *)location_corelocation_get_fd,
-		(location_provider_handle_func *)location_corelocation_handle
-	},
-#endif
-	{
-		"manual",
-		(location_provider_init_func *)location_manual_init,
-		(location_provider_start_func *)location_manual_start,
-		(location_provider_free_func *)location_manual_free,
-		(location_provider_print_help_func *)
-		location_manual_print_help,
-		(location_provider_set_option_func *)
-		location_manual_set_option,
-		(location_provider_get_fd_func *)location_manual_get_fd,
-		(location_provider_handle_func *)location_manual_handle
-	},
-	{ NULL }
-};
 
 /* Bounds for parameters. */
 #define MIN_LAT   -90.0
@@ -566,7 +445,7 @@ print_help(const char *program_name)
 }
 
 static void
-print_method_list()
+print_method_list(const gamma_method_t *gamma_methods)
 {
 	fputs(_("Available adjustment methods:\n"), stdout);
 	for (int i = 0; gamma_methods[i].name != NULL; i++) {
@@ -581,7 +460,7 @@ print_method_list()
 }
 
 static void
-print_provider_list()
+print_provider_list(const location_provider_t location_providers[])
 {
 	fputs(_("Available location providers:\n"), stdout);
 	for (int i = 0; location_providers[i].name != NULL; i++) {
@@ -900,13 +779,13 @@ location_is_valid(const location_t *location)
 }
 
 static const gamma_method_t *
-find_gamma_method(const char *name)
+find_gamma_method(const gamma_method_t gamma_methods[], const char *name)
 {
 	const gamma_method_t *method = NULL;
 	for (int i = 0; gamma_methods[i].name != NULL; i++) {
 		const gamma_method_t *m = &gamma_methods[i];
 		if (strcasecmp(name, m->name) == 0) {
-		        method = m;
+			method = m;
 			break;
 		}
 	}
@@ -915,7 +794,8 @@ find_gamma_method(const char *name)
 }
 
 static const location_provider_t *
-find_location_provider(const char *name)
+find_location_provider(
+	const location_provider_t location_providers[], const char *name)
 {
 	const location_provider_t *provider = NULL;
 	for (int i = 0; location_providers[i].name != NULL; i++) {
@@ -1333,8 +1213,41 @@ main(int argc, char *argv[])
 	/* Temperature for manual mode */
 	int temp_set = -1;
 
+	/* List of gamma methods. */
+	const gamma_method_t gamma_methods[] = {
+#ifdef ENABLE_DRM
+		drm_gamma_method,
+#endif
+#ifdef ENABLE_RANDR
+		randr_gamma_method,
+#endif
+#ifdef ENABLE_VIDMODE
+		vidmode_gamma_method,
+#endif
+#ifdef ENABLE_QUARTZ
+		quartz_gamma_method,
+#endif
+#ifdef ENABLE_WINGDI
+		w32gdi_gamma_method,
+#endif
+		dummy_gamma_method,
+		{ NULL }
+	};
+
 	const gamma_method_t *method = NULL;
 	char *method_args = NULL;
+
+	/* List of location providers. */
+	const location_provider_t location_providers[] = {
+#ifdef ENABLE_GEOCLUE2
+		geoclue2_location_provider,
+#endif
+#ifdef ENABLE_CORELOCATION
+		corelocation_location_provider,
+#endif
+		manual_location_provider,
+		{ NULL }
+	};
 
 	const location_provider_t *provider = NULL;
 	char *provider_args = NULL;
@@ -1386,7 +1299,7 @@ main(int argc, char *argv[])
 		case 'l':
 			/* Print list of providers if argument is `list' */
 			if (strcasecmp(optarg, "list") == 0) {
-				print_provider_list();
+				print_provider_list(location_providers);
 				exit(EXIT_SUCCESS);
 			}
 
@@ -1413,7 +1326,8 @@ main(int argc, char *argv[])
 			}
 
 			/* Lookup provider from name. */
-			provider = find_location_provider(provider_name);
+			provider = find_location_provider(
+				location_providers, provider_name);
 			if (provider == NULL) {
 				fprintf(stderr, _("Unknown location provider"
 						  " `%s'.\n"), provider_name);
@@ -1430,7 +1344,7 @@ main(int argc, char *argv[])
 		case 'm':
 			/* Print list of methods if argument is `list' */
 			if (strcasecmp(optarg, "list") == 0) {
-				print_method_list();
+				print_method_list(gamma_methods);
 				exit(EXIT_SUCCESS);
 			}
 
@@ -1442,7 +1356,7 @@ main(int argc, char *argv[])
 			}
 
 			/* Find adjustment method by name. */
-			method = find_gamma_method(optarg);
+			method = find_gamma_method(gamma_methods, optarg);
 			if (method == NULL) {
 				/* TRANSLATORS: This refers to the method
 				   used to adjust colors e.g VidMode */
@@ -1603,7 +1517,7 @@ main(int argc, char *argv[])
 					      "adjustment-method") == 0) {
 				if (method == NULL) {
 					method = find_gamma_method(
-						setting->value);
+						gamma_methods, setting->value);
 					if (method == NULL) {
 						fprintf(stderr, _("Unknown"
 								  " adjustment"
@@ -1617,6 +1531,7 @@ main(int argc, char *argv[])
 					      "location-provider") == 0) {
 				if (provider == NULL) {
 					provider = find_location_provider(
+						location_providers,
 						setting->value);
 					if (provider == NULL) {
 						fprintf(stderr, _("Unknown"

--- a/src/redshift.h
+++ b/src/redshift.h
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU General Public License
    along with Redshift.  If not, see <http://www.gnu.org/licenses/>.
 
-   Copyright (c) 2013-2014  Jon Lund Steffensen <jonlst@gmail.com>
+   Copyright (c) 2013-2017  Jon Lund Steffensen <jonlst@gmail.com>
 */
 
 #ifndef REDSHIFT_REDSHIFT_H
@@ -47,14 +47,16 @@ typedef struct {
 
 
 /* Gamma adjustment method */
-typedef int gamma_method_init_func(void *state);
-typedef int gamma_method_start_func(void *state);
-typedef void gamma_method_free_func(void *state);
+typedef struct gamma_state gamma_state_t;
+
+typedef int gamma_method_init_func(gamma_state_t **state);
+typedef int gamma_method_start_func(gamma_state_t *state);
+typedef void gamma_method_free_func(gamma_state_t *state);
 typedef void gamma_method_print_help_func(FILE *f);
-typedef int gamma_method_set_option_func(void *state, const char *key,
+typedef int gamma_method_set_option_func(gamma_state_t *state, const char *key,
 					 const char *value);
-typedef void gamma_method_restore_func(void *state);
-typedef int gamma_method_set_temperature_func(void *state,
+typedef void gamma_method_restore_func(gamma_state_t *state);
+typedef int gamma_method_set_temperature_func(gamma_state_t *state,
 					      const color_setting_t *setting);
 
 typedef struct {
@@ -83,15 +85,17 @@ typedef struct {
 
 
 /* Location provider */
-typedef int location_provider_init_func(void *state);
-typedef int location_provider_start_func(void *state);
-typedef void location_provider_free_func(void *state);
+typedef struct location_state location_state_t;
+
+typedef int location_provider_init_func(location_state_t **state);
+typedef int location_provider_start_func(location_state_t *state);
+typedef void location_provider_free_func(location_state_t *state);
 typedef void location_provider_print_help_func(FILE *f);
-typedef int location_provider_set_option_func(void *state, const char *key,
-					      const char *value);
-typedef int location_provider_get_fd_func(void *state);
+typedef int location_provider_set_option_func(
+	location_state_t *state, const char *key, const char *value);
+typedef int location_provider_get_fd_func(location_state_t *state);
 typedef int location_provider_handle_func(
-	void *state, location_t *location, int *available);
+	location_state_t *state, location_t *location, int *available);
 
 typedef struct {
 	char *name;

--- a/src/redshift.h
+++ b/src/redshift.h
@@ -23,6 +23,9 @@
 #include <stdio.h>
 #include <stdlib.h>
 
+/* The color temperature when no adjustment is applied. */
+#define NEUTRAL_TEMP  6500
+
 
 /* Location */
 typedef struct {
@@ -44,6 +47,35 @@ typedef struct {
 	float gamma[3];
 	float brightness;
 } color_setting_t;
+
+/* Program modes. */
+typedef enum {
+	PROGRAM_MODE_CONTINUAL,
+	PROGRAM_MODE_ONE_SHOT,
+	PROGRAM_MODE_PRINT,
+	PROGRAM_MODE_RESET,
+	PROGRAM_MODE_MANUAL
+} program_mode_t;
+
+/* Time range.
+   Fields are offsets from midnight in seconds. */
+typedef struct {
+	int start;
+	int end;
+} time_range_t;
+
+/* Transition scheme.
+   The solar elevations at which the transition begins/ends,
+   and the association color settings. */
+typedef struct {
+	double high;
+	double low;
+	int use_time; /* When enabled, ignore elevation and use time ranges. */
+	time_range_t dawn;
+	time_range_t dusk;
+	color_setting_t day;
+	color_setting_t night;
+} transition_scheme_t;
 
 
 /* Gamma adjustment method */


### PR DESCRIPTION
- Move the struct defining the entry points for each module (adjustment methods and location providers) to their respective files.
- Make each module allocate its own state data so the structs can be opaque and `redshift.c` doesn't need to know about them.
- Move the state structs out of the header files and into the `.c` files of their respective modules.
- Move options parsing to new `options.c`.
- Add function to simplify resetting `color_setting_t`.