### PR TITLE
Preserve command-line option

### DIFF
--- a/redshift.1
+++ b/redshift.1
@@ -55,13 +55,19 @@ Method to use to set color temperature
 (Use `-m list' to see available methods)
 .TP
 \fB\-o\fR
-One shot mode (do not continuously adjust color temperature)
+One-shot mode (do not continuously adjust color temperature). Use this with the
+`-P` option to clear the existing gamma ramps before applying the new color
+temperature.
 .TP
 \fB\-O\fR TEMP
-One shot manual mode (set color temperature)
+One-shot manual mode (set color temperature).  Use this with the `-P` option
+to clear the existing gamma ramps before applying the new color temperature.
 .TP
 \fB\-p\fR
 Print mode (only print parameters and exit)
+.TP
+\fB\-P\fR
+Reset existing gamma ramps before applying new color effect.
 .TP
 \fB\-x\fR
 Reset mode (remove adjustment from screen)

--- a/src/gamma-drm.c
+++ b/src/gamma-drm.c
@@ -269,7 +269,8 @@ drm_set_option(drm_state_t *state, const char *key, const char *value)
 }
 
 static int
-drm_set_temperature(drm_state_t *state, const color_setting_t *setting)
+drm_set_temperature(
+	drm_state_t *state, const color_setting_t *setting, int preserve)
 {
 	drm_crtc_state_t *crtcs = state->crtcs;
 	int last_gamma_size = 0;

--- a/src/gamma-dummy.c
+++ b/src/gamma-dummy.c
@@ -69,7 +69,8 @@ gamma_dummy_set_option(void *state, const char *key, const char *value)
 }
 
 static int
-gamma_dummy_set_temperature(void *state, const color_setting_t *setting)
+gamma_dummy_set_temperature(
+	void *state, const color_setting_t *setting, int preserve)
 {
 	printf(_("Temperature: %i\n"), setting->temperature);
 	return 0;

--- a/src/gamma-vidmode.c
+++ b/src/gamma-vidmode.c
@@ -39,7 +39,6 @@
 
 typedef struct {
 	Display *display;
-	int preserve;
 	int screen_num;
 	int ramp_size;
 	uint16_t *saved_ramps;
@@ -55,8 +54,6 @@ vidmode_init(vidmode_state_t **state)
 	vidmode_state_t *s = *state;
 	s->screen_num = -1;
 	s->saved_ramps = NULL;
-
-	s->preserve = 1;
 
 	/* Open display */
 	s->display = XOpenDisplay(NULL);
@@ -145,9 +142,7 @@ vidmode_print_help(FILE *f)
 
 	/* TRANSLATORS: VidMode help output
 	   left column must not be translated */
-	fputs(_("  screen=N\t\tX screen to apply adjustments to\n"
-		"  preserve={0,1}\tWhether existing gamma should be"
-		" preserved\n"),
+	fputs(_("  screen=N\t\tX screen to apply adjustments to\n"),
 	      f);
 	fputs("\n", f);
 }
@@ -158,7 +153,10 @@ vidmode_set_option(vidmode_state_t *state, const char *key, const char *value)
 	if (strcasecmp(key, "screen") == 0) {
 		state->screen_num = atoi(value);
 	} else if (strcasecmp(key, "preserve") == 0) {
-		state->preserve = atoi(value);
+		fprintf(stderr, _("Parameter `%s` is now always on; "
+				  " Use the `%s` command-line option"
+				  " to disable.\n"),
+			key, "-P");
 	} else {
 		fprintf(stderr, _("Unknown method parameter: `%s'.\n"), key);
 		return -1;
@@ -185,8 +183,8 @@ vidmode_restore(vidmode_state_t *state)
 }
 
 static int
-vidmode_set_temperature(vidmode_state_t *state,
-			const color_setting_t *setting)
+vidmode_set_temperature(
+	vidmode_state_t *state, const color_setting_t *setting, int preserve)
 {
 	int r;
 
@@ -201,7 +199,7 @@ vidmode_set_temperature(vidmode_state_t *state,
 	uint16_t *gamma_g = &gamma_ramps[1*state->ramp_size];
 	uint16_t *gamma_b = &gamma_ramps[2*state->ramp_size];
 
-	if (state->preserve) {
+	if (preserve) {
 		/* Initialize gamma ramps from saved state */
 		memcpy(gamma_ramps, state->saved_ramps,
 		       3*state->ramp_size*sizeof(uint16_t));

--- a/src/gamma-w32gdi.c
+++ b/src/gamma-w32gdi.c
@@ -42,7 +42,6 @@
 
 typedef struct {
 	WORD *saved_ramps;
-	int preserve;
 } w32gdi_state_t;
 
 
@@ -54,7 +53,6 @@ w32gdi_init(w32gdi_state_t **state)
 
 	w32gdi_state_t *s = *state;
 	s->saved_ramps = NULL;
-	s->preserve = 1;
 
 	return 0;
 }
@@ -116,20 +114,16 @@ w32gdi_print_help(FILE *f)
 {
 	fputs(_("Adjust gamma ramps with the Windows GDI.\n"), f);
 	fputs("\n", f);
-
-	/* TRANSLATORS: Windows GDI help output
-	   left column must not be translated */
-	fputs(_("  preserve={0,1}\tWhether existing gamma should be"
-		" preserved\n"),
-	      f);
-	fputs("\n", f);
 }
 
 static int
 w32gdi_set_option(w32gdi_state_t *state, const char *key, const char *value)
 {
 	if (strcasecmp(key, "preserve") == 0) {
-		state->preserve = atoi(value);
+		fprintf(stderr, _("Parameter `%s` is now always on; "
+				  " Use the `%s` command-line option"
+				  " to disable.\n"),
+			key, "-P");
 	} else {
 		fprintf(stderr, _("Unknown method parameter: `%s'.\n"), key);
 		return -1;
@@ -163,8 +157,8 @@ w32gdi_restore(w32gdi_state_t *state)
 }
 
 static int
-w32gdi_set_temperature(w32gdi_state_t *state,
-		       const color_setting_t *setting)
+w32gdi_set_temperature(
+	w32gdi_state_t *state, const color_setting_t *setting, int preserve)
 {
 	BOOL r;
 
@@ -187,7 +181,7 @@ w32gdi_set_temperature(w32gdi_state_t *state,
 	WORD *gamma_g = &gamma_ramps[1*GAMMA_RAMP_SIZE];
 	WORD *gamma_b = &gamma_ramps[2*GAMMA_RAMP_SIZE];
 
-	if (state->preserve) {
+	if (preserve) {
 		/* Initialize gamma ramps from saved state */
 		memcpy(gamma_ramps, state->saved_ramps,
 		       3*GAMMA_RAMP_SIZE*sizeof(WORD));

--- a/src/options.c
+++ b/src/options.c
@@ -189,6 +189,8 @@ print_help(const char *program_name)
 		" color temperature)\n"
 		"  -O TEMP\tOne shot manual mode (set color temperature)\n"
 		"  -p\t\tPrint mode (only print parameters and exit)\n"
+		"  -P\t\tReset existing gamma ramps before applying new"
+		" color effect\n"
 		"  -x\t\tReset mode (remove adjustment from screen)\n"
 		"  -r\t\tDisable fading between color temperatures\n"
 		"  -t DAY:NIGHT\tColor temperature to set at daytime/night\n"),
@@ -318,6 +320,7 @@ options_init(options_t *options)
 	options->provider_args = NULL;
 
 	options->use_fade = -1;
+	options->preserve_gamma = 1;
 	options->mode = PROGRAM_MODE_CONTINUAL;
 	options->verbose = 0;
 }
@@ -334,7 +337,7 @@ options_parse_args(
 
 	/* Parse command line arguments. */
 	int opt;
-	while ((opt = getopt(argc, argv, "b:c:g:hl:m:oO:prt:vVx")) != -1) {
+	while ((opt = getopt(argc, argv, "b:c:g:hl:m:oO:pPrt:vVx")) != -1) {
 		switch (opt) {
 		case 'b':
 			parse_brightness_string(
@@ -454,6 +457,9 @@ options_parse_args(
 			break;
 		case 'p':
 			options->mode = PROGRAM_MODE_PRINT;
+			break;
+		case 'P':
+			options->preserve_gamma = 0;
 			break;
 		case 'r':
 			options->use_fade = 0;

--- a/src/options.h
+++ b/src/options.h
@@ -34,6 +34,8 @@ typedef struct {
 	int temp_set;
 	/* Whether to fade between large skips in color temperature. */
 	int use_fade;
+	/* Whether to preserve gamma ramps if supported by gamma method. */
+	int preserve_gamma;
 
 	/* Selected gamma method. */
 	const gamma_method_t *method;

--- a/src/redshift.c
+++ b/src/redshift.c
@@ -603,7 +603,7 @@ run_continual_mode(const location_provider_t *provider,
 		   const transition_scheme_t *scheme,
 		   const gamma_method_t *method,
 		   gamma_state_t *method_state,
-		   int use_fade, int verbose)
+		   int use_fade, int preserve_gamma, int verbose)
 {
 	int r;
 
@@ -796,7 +796,8 @@ run_continual_mode(const location_provider_t *provider,
 		}
 
 		/* Adjust temperature */
-		r = method->set_temperature(method_state, &interp);
+		r = method->set_temperature(
+			method_state, &interp, preserve_gamma);
 		if (r < 0) {
 			fputs(_("Temperature adjustment failed.\n"),
 			      stderr);
@@ -1227,7 +1228,7 @@ main(int argc, char *argv[])
 		if (options.mode != PROGRAM_MODE_PRINT) {
 			/* Adjust temperature */
 			r = options.method->set_temperature(
-				method_state, &interp);
+				method_state, &interp, options.preserve_gamma);
 			if (r < 0) {
 				fputs(_("Temperature adjustment failed.\n"),
 				      stderr);
@@ -1256,7 +1257,8 @@ main(int argc, char *argv[])
 		/* Adjust temperature */
 		color_setting_t manual = scheme->day;
 		manual.temperature = options.temp_set;
-		r = options.method->set_temperature(method_state, &manual);
+		r = options.method->set_temperature(
+			method_state, &manual, options.preserve_gamma);
 		if (r < 0) {
 			fputs(_("Temperature adjustment failed.\n"), stderr);
 			options.method->free(method_state);
@@ -1278,7 +1280,7 @@ main(int argc, char *argv[])
 		color_setting_t reset;
 		color_setting_reset(&reset);
 
-		r = options.method->set_temperature(method_state, &reset);
+		r = options.method->set_temperature(method_state, &reset, 0);
 		if (r < 0) {
 			fputs(_("Temperature adjustment failed.\n"), stderr);
 			options.method->free(method_state);
@@ -1299,7 +1301,8 @@ main(int argc, char *argv[])
 		r = run_continual_mode(
 			options.provider, location_state, scheme,
 			options.method, method_state,
-			options.use_fade, options.verbose);
+			options.use_fade, options.preserve_gamma,
+			options.verbose);
 		if (r < 0) exit(EXIT_FAILURE);
 	}
 	break;

--- a/src/redshift.h
+++ b/src/redshift.h
@@ -88,8 +88,8 @@ typedef void gamma_method_print_help_func(FILE *f);
 typedef int gamma_method_set_option_func(gamma_state_t *state, const char *key,
 					 const char *value);
 typedef void gamma_method_restore_func(gamma_state_t *state);
-typedef int gamma_method_set_temperature_func(gamma_state_t *state,
-					      const color_setting_t *setting);
+typedef int gamma_method_set_temperature_func(
+	gamma_state_t *state, const color_setting_t *setting, int preserve);
 
 typedef struct {
 	char *name;


### PR DESCRIPTION
Changes each adjustment method to take a preserve parameter when
setting the temperature instead of parsing the preserve option
from the command line/configuration file. This helps resolve the
issues around #513:

- This allows the preserve option to be implemented as a
  command-line switch (-P). This switch _disables_ the preservation
  of existing gamma ramps. Having a command-line switch makes it
  easier to use directly with manual or one-shot mode.
- The preserve options is on by default, so continual mode as well
  as other modes will default to applying the color adjustment
  on top of the current gamma ramps.
- Preserve is always disabled in reset mode so resetting works
  as expected again.