### PR TITLE
Fix #335: Set period to none when disabled

### DIFF
--- a/src/redshift.c
+++ b/src/redshift.c
@@ -723,6 +723,7 @@ run_continual_mode(const location_provider_t *provider,
 			scheme, transition_prog, &target_interp);
 
 		if (disabled) {
+			period = PERIOD_NONE;
 			color_setting_reset(&target_interp);
 		}
 


### PR DESCRIPTION
This allows for hooks to be run when redshift is disabled. See #335 