### PR TITLE
control brightness in a running redshift process via FIFO

### DIFF
--- a/src/options.c
+++ b/src/options.c
@@ -193,7 +193,9 @@ print_help(const char *program_name)
 		" color effect\n"
 		"  -x\t\tReset mode (remove adjustment from screen)\n"
 		"  -r\t\tDisable fading between color temperatures\n"
-		"  -t DAY:NIGHT\tColor temperature to set at daytime/night\n"),
+		"  -t DAY:NIGHT\tColor temperature to set at daytime/night\n"
+		"  -B FILE\tcreate FILE as a fifo which can be used to\n"
+		"  \t\tcontrol brightness by writing values to it\n"),
 	      stdout);
 	fputs("\n", stdout);
 
@@ -323,6 +325,8 @@ options_init(options_t *options)
 	options->preserve_gamma = 1;
 	options->mode = PROGRAM_MODE_CONTINUAL;
 	options->verbose = 0;
+	
+	options->brightness_fn = NULL;
 }
 
 /* Parse a single option from the command-line. */
@@ -477,6 +481,10 @@ parse_command_line_option(
 	case 'x':
 		options->mode = PROGRAM_MODE_RESET;
 		break;
+	case 'B':
+		if(options->brightness_fn) free(options->brightness_fn);
+		options->brightness_fn = strdup(value);
+		break;
 	case '?':
 		fputs(_("Try `-h' for more information.\n"), stderr);
 		return -1;
@@ -495,7 +503,7 @@ options_parse_args(
 {
 	const char* program_name = argv[0];
 	int opt;
-	while ((opt = getopt(argc, argv, "b:c:g:hl:m:oO:pPrt:vVx")) != -1) {
+	while ((opt = getopt(argc, argv, "b:B:c:g:hl:m:oO:pPrt:vVx")) != -1) {
 		char option = opt;
 		int r = parse_command_line_option(
 			option, optarg, options, program_name, gamma_methods,
@@ -541,6 +549,9 @@ parse_config_file_option(
 		if (isnan(options->scheme.night.brightness)) {
 			options->scheme.night.brightness = atof(value);
 		}
+	} else if (strcasecmp(key, "brightness-fn") == 0) {
+		if(options->brightness_fn) free(options->brightness_fn);
+		options->brightness_fn = strdup(value);
 	} else if (strcasecmp(key, "elevation-high") == 0) {
 		options->scheme.high = atof(value);
 	} else if (strcasecmp(key, "elevation-low") == 0) {

--- a/src/options.h
+++ b/src/options.h
@@ -46,6 +46,9 @@ typedef struct {
 	const location_provider_t *provider;
 	/* Arguments for location provider. */
 	char *provider_args;
+	
+	/* dynamic brightness control via a fifo -- filename to use */
+	char* brightness_fn;
 } options_t;
 
 

--- a/src/redshift.c
+++ b/src/redshift.c
@@ -29,6 +29,13 @@
 #include <locale.h>
 #include <errno.h>
 
+/* for creating FIFOs 
+  (will probably not work on Windows)
+  */
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+
 /* poll.h is not available on Windows but there is no Windows location provider
    using polling. On Windows, we just define some stubs to make things compile.
    */
@@ -484,6 +491,7 @@ method_try_start(const gamma_method_t *method,
 }
 
 
+
 /* Check whether gamma is within allowed levels. */
 static int
 gamma_is_valid(const float gamma[3])
@@ -603,10 +611,15 @@ run_continual_mode(const location_provider_t *provider,
 		   const transition_scheme_t *scheme,
 		   const gamma_method_t *method,
 		   gamma_state_t *method_state,
-		   int use_fade, int preserve_gamma, int verbose)
+		   int use_fade, int preserve_gamma, int verbose,
+		   int brightness_fd)
 {
 	int r;
-
+	double brightness_override = -1.0;
+	const size_t read_buf_size = 512;
+	/* buffer for reading extra data from brightness_fd */
+	char read_buf[read_buf_size];
+	
 	/* Short fade parameters */
 	int fade_length = 0;
 	int fade_time = 0;
@@ -721,6 +734,11 @@ run_continual_mode(const location_provider_t *provider,
 		color_setting_t target_interp;
 		interpolate_transition_scheme(
 			scheme, transition_prog, &target_interp);
+			
+		/* use manually supplied brightness value */
+		if(brightness_override >= 0.0 && brightness_override <= 1.0) {
+			target_interp.brightness = brightness_override;
+		}
 
 		if (disabled) {
 			period = PERIOD_NONE;
@@ -821,57 +839,112 @@ run_continual_mode(const location_provider_t *provider,
 			loc_fd = provider->get_fd(location_state);
 		}
 
-		if (loc_fd >= 0) {
+		/* use poll() for waiting if updates are possible
+		   for either the location or brightness setting */
+		if (loc_fd >= 0 || brightness_fd >= 0) {
 			/* Provider is dynamic. */
-			struct pollfd pollfds[1];
-			pollfds[0].fd = loc_fd;
-			pollfds[0].events = POLLIN;
-			int r = poll(pollfds, 1, delay);
+			/* we have either one or two fds to listen for */
+			struct pollfd pollfds[2];
+			int nfds = 0;
+			if(loc_fd >= 0) {
+				pollfds[nfds].fd = loc_fd;
+				pollfds[nfds].events = POLLIN;
+				pollfds[nfds].revents = 0;
+				nfds++;
+			}
+			if(brightness_fd >= 0) {
+				/* note: should be a pipe, regular file will always
+				   be available for reading */
+				pollfds[nfds].fd = brightness_fd;
+				pollfds[nfds].events = POLLIN;
+				pollfds[nfds].revents = 0;
+				nfds++;
+			}
+			int r = poll(pollfds, nfds, delay);
 			if (r < 0) {
 				if (errno == EINTR) continue;
 				perror("poll");
-				fputs(_("Unable to get location"
-					" from provider.\n"), stderr);
+				fputs(_("Unable to get location or brightness updates\n"), stderr);
 				return -1;
 			} else if (r == 0) {
 				continue;
 			}
-
-			/* Get new location and availability
-			   information. */
-			location_t new_loc;
-			int new_available;
-			r = provider->handle(
-				location_state, &new_loc,
-				&new_available);
-			if (r < 0) {
-				fputs(_("Unable to get location"
-					" from provider.\n"), stderr);
-				return -1;
+			
+			/* check both possible fds if there is new data */
+			
+			/* loc_fd is always at index 0 */
+			if(loc_fd >= 0 && pollfds[0].revents & POLLIN) {
+				/* Get new location and availability
+				   information. */
+				location_t new_loc;
+				int new_available;
+				r = provider->handle(
+					location_state, &new_loc,
+					&new_available);
+				if (r < 0) {
+					fputs(_("Unable to get location"
+						" from provider.\n"), stderr);
+					return -1;
+				}
+	
+				if (!new_available &&
+				    new_available != location_available) {
+					fputs(_("Location is temporarily"
+					        " unavailable; Using previous"
+						" location until it becomes"
+						" available...\n"), stderr);
+				}
+	
+				if (new_available &&
+				    (new_loc.lat != loc.lat ||
+				     new_loc.lon != loc.lon ||
+				     new_available != location_available)) {
+					loc = new_loc;
+					print_location(&loc);
+				}
+	
+				location_available = new_available;
+	
+				if (!location_is_valid(&loc)) {
+					fputs(_("Invalid location returned"
+						" from provider.\n"), stderr);
+					return -1;
+				}
 			}
-
-			if (!new_available &&
-			    new_available != location_available) {
-				fputs(_("Location is temporarily"
-				        " unavailable; Using previous"
-					" location until it becomes"
-					" available...\n"), stderr);
-			}
-
-			if (new_available &&
-			    (new_loc.lat != loc.lat ||
-			     new_loc.lon != loc.lon ||
-			     new_available != location_available)) {
-				loc = new_loc;
-				print_location(&loc);
-			}
-
-			location_available = new_available;
-
-			if (!location_is_valid(&loc)) {
-				fputs(_("Invalid location returned"
-					" from provider.\n"), stderr);
-				return -1;
+			/* check brightness setting */
+			if(brightness_fd >= 0) {
+				/* either in position 0 or 1 */
+				int i = 0;
+				if(loc_fd >= 0) i = 1;
+				if(pollfds[i].revents & POLLIN) {
+					/* try to read new brightness value */
+					double brightness_tmp;
+					ssize_t r1 = read(brightness_fd,read_buf,read_buf_size-1);
+					if(r1 > 0) {
+						read_buf[r1] = 0;
+						/* try to parse the first part newly written */
+						if(sscanf(read_buf,"%lf",&brightness_tmp) == 1) {
+							brightness_override = brightness_tmp;
+						}
+						else fputs("Invalid brightness value read\n",stderr);
+						/* note: the above warning message will crash redshift-gtk */
+					}
+					
+					/* read and discard all remaining available data (one write
+					   should only set one value + skip any invalid data) */
+					while(1) {
+						/* r1 is the return value of the previous read() */
+						if(r1 == -1) {
+							/* EAGAIN or EWOULDBLOCK is not an error, 
+							   there is no more data */
+							if(errno == EAGAIN || errno == EWOULDBLOCK) break;
+							fputs("Error reading from brightness fifo!\n",stderr);
+							return -1;
+						}
+						if((size_t)r1 < read_buf_size-1) break; /* end of data too */
+						ssize_t r1 = read(brightness_fd,read_buf,read_buf_size-1);
+					}
+				}
 			}
 		} else {
 			systemtime_msleep(delay);
@@ -1299,11 +1372,46 @@ main(int argc, char *argv[])
 	break;
 	case PROGRAM_MODE_CONTINUAL:
 	{
+		int brightness_fd = -1;
+		if(options.brightness_fn) {
+			/* try to create a fifo and open it
+			   
+			   poll() does not work well with regular files, so this tries to
+			   ensure that the FIFO is being created here
+			  
+			   note: this will fail if the file already exists
+			   
+			   note: there is a possible race condition if the file is deleted
+				between the mkfifo() and the open() calls and re-created in
+				differently -- maybe there should be an extra check after
+				the open() call if we really have a fifo()
+			*/
+			if(mkfifo(options.brightness_fn,S_IRUSR | S_IWUSR) == 0) {
+				/* note: O_RDWR is needed so we do not receive POLLHUP if a
+				    writer closes the fifo (it is not an error, it can be
+				    reopened by another writer later: e.g. typical usage
+				    would be 'echo 0.5 > brightness_fifo') */
+				brightness_fd = open(options.brightness_fn,O_RDWR |
+					O_CLOEXEC | O_NONBLOCK);
+			}
+			if(brightness_fd == -1) {
+				fputs("Error creating brightness control file!\n",stderr);
+				exit(EXIT_FAILURE);
+			}
+		}
+		
 		r = run_continual_mode(
 			options.provider, location_state, scheme,
 			options.method, method_state,
 			options.use_fade, options.preserve_gamma,
-			options.verbose);
+			options.verbose, brightness_fd);
+			
+		/* close and delete the fifo for brightness control if it
+		   was created previously */
+		if(brightness_fd >= 0) {
+			close(brightness_fd);
+			unlink(options.brightness_fn);
+		}
 		if (r < 0) exit(EXIT_FAILURE);
 	}
 	break;

--- a/yoga-brightness.sh
+++ b/yoga-brightness.sh
@@ -1,0 +1,40 @@
+#!/bin/sh
+
+# Kondor Dániel, 2018, kondor.dani@gmail.com
+# simple script to adjust OLED (or similar) display brightness
+# based on Ivo's answer here: https://askubuntu.com/questions/824949/lenovo-thinkpad-x1-yoga-oled-brightness
+# but simplified to not update the 'official' but useless setting under /sys
+# this way it does not need root priviliges
+# also, added the possibility to integrate with Redshift
+
+# usage: ./yoga-brightness.sh up|down
+# in my case I could map these to the brightness keys of my laptop under
+#	GNOME's keyboard shortcuts settings
+
+
+dir=$XDG_RUNTIME_DIR
+test -d "$dir" || exit 0
+
+test -e "$dir/brightness" || echo 1.0 > "$dir/brightness"
+
+VAL=`cat "$dir/brightness"`
+
+if [ "$1" = "down" ]; then
+    VAL=`echo "$VAL"-0.05 | bc`
+else
+    VAL=`echo "$VAL"+0.05 | bc`
+fi
+
+if [ `echo "$VAL < 0.0" | bc` = "1" ]; then
+    VAL=0.0
+elif [ `echo "$VAL > 1.0" | bc` = "1" ]; then
+    VAL=1.0
+fi
+
+if [ -p "$dir/redshift-brightness" ]; then
+    echo $VAL > "$dir/redshift-brightness"
+else 
+    xrandr --output eDP-1 --brightness $VAL
+fi
+
+echo $VAL > "$dir/brightness"


### PR DESCRIPTION
addresses https://github.com/jonls/redshift/issues/129 and related

main motivation: OLED (and similar) screens do not have a backlight setting, brighness is controlled on the pixel level, AFAIK the only way to control screen brightness is with gamma ramps, which can be achieved e.g. by xrandr:
xrandr --output eDP-1 --brightness 1.0
unfortunately, this method conflicts with redshift; once redshift started, the brightness cannot be controlled any longer (redshift only supports setting to a fixed value)

this patch makes redshift 'listen' to commands for setting the brightness via a FIFO (names pipe) it creates; it can be used e.g. from external scripts to provide a way to control screen brightness, or directly from the command line

the name of the FIFO can be specified with the -B command line option
or with the brightness-fn setting in the config file

added an example script for brightness control as well, which I could successfully map to my brightness hotkeys in GNOME keyboard options


potential problems:
  -- not a very 'elegant' way to do (but much simpler than doing something with e.g. dbus)
  -- doing nasty things (e.g. 'yes 0.6 > /tmp/redshift-brightness'), could have bad results; for me it does not cause crash or hang anything, but seems to mess up this functionality; OOTH, any malicious program could already create similar problems by using xrandr directly
  -- only works with a FIFO (that the program creates), not with a regular file
  -- cannot 'read' the current value from the FIFO

Hope this could be useful for other as well :)
