### PR TITLE
Travis: Run "brew upgrade python" to install Python 3 on macOS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ before_install: |
     brew install gettext
     brew link --force gettext
     brew install intltool
-    brew install python3
+    brew upgrade python
   fi
 
 install:


### PR DESCRIPTION
As of March 2018, Travis CI fails on macOS:

```
Error: python 2.7.14 is already installed
To upgrade to 3.6.4_4, run `brew upgrade python`
```

This commit fixes the issue.