### PR TITLE
Update rpm spec file to version 1.12

### DIFF
--- a/contrib/redshift.spec
+++ b/contrib/redshift.spec
@@ -1,5 +1,5 @@
 Name: redshift
-Version: 1.11
+Version: 1.12
 Release: 1%{dist}
 Summary: Adjusts the color temperature of your screen according to time of day
 Group: Applications/System
@@ -83,6 +83,8 @@ gtk-update-icon-cache %{_datadir}/icons/hicolor &>/dev/null || :
 %{_datadir}/appdata/redshift-gtk.appdata.xml
 
 %changelog
+* Sun Jul 8 2018 Ben van der Harg <benvanderharg@yandex.com> - 1.12.1
+- Update to 1.12
 * Sat Jan 2 2016 Jon Lund Steffensen <jonlst@gmail.com> - 1.11-1
 - Update to 1.11
 


### PR DESCRIPTION
Hi Jon,

Just tried building the rpm packages for my own system as fedora 28 has not yet provided a 1.12 package. While doing so I noticed the spec file was not updated from 1.11 to 1.12. The attached commit fixes this issue.

Kind regards,

Ben