### PR TITLE
Travis: Fix automake on macOS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,13 @@ before_install: |
     brew link --force gettext
     brew install intltool
     brew upgrade python
+    
+    # distuninstallcheck fails on macOS when automake 1.16 or 1.16.1 is used.
+    # http://gnu-automake.7480.n7.nabble.com/bug-31222-automake-1-16-1-am-pep3147-tweak-bug-td22937.html
+    # No upstream release yet, use upstream patch.
+    pushd /usr/local/Cellar/automake/*/share/automake-*
+    curl "https://git.savannah.gnu.org/cgit/automake.git/patch/?id=a348d830659fffd2cfc42994524783b07e69b4b5" | tail -n 14 | sudo patch -p2
+    popd
   fi
 
 install:


### PR DESCRIPTION
Fix #643.
* Temporary workaround for `distuninstallcheck` error.
* Get upstream patch (https://git.savannah.gnu.org/cgit/automake.git/patch/?id=a348d830659fffd2cfc42994524783b07e69b4b5) and apply it before running `./bootstrap`.
