### PR TITLE
Add a delay between restarts in systemd service

### DIFF
--- a/data/systemd/redshift.service.in
+++ b/data/systemd/redshift.service.in
@@ -2,10 +2,13 @@
 Description=Redshift display colour temperature adjustment
 Documentation=http://jonls.dk/redshift/
 After=display-manager.service
+StartLimitIntervalSec=30s
+StartLimitBurst=30
 
 [Service]
 ExecStart=@bindir@/redshift
 Restart=always
+RestartSec=1s
 
 [Install]
 WantedBy=default.target


### PR DESCRIPTION
Sometimes, there's no "display-manager" service, the Xorg server
is then initialized after the TTY login (maybe with xorg-xinit).

This change gives some time (~30 seconds) to start the Xorg server
and starts redshift smoothly.

The defaults are:
```bash
# /etc/system/system.conf
DefaultRestartSec=100ms
DefaultStartLimitIntervalSec=10s
DefaultStartLimitBurst=5
```
If a service is restared more than 5 times within 10 seconds, it
will not be permitted to start any more.

Incrementing the `RestartSec` to 1s, and raising the `StartLimitIntervalSec`
to 30s, and `StartLimitBurst` to 30, it should give the user enough time to
login and start X.