### PR TITLE
Fix "Some translated strings are still in English" issue

### DIFF
--- a/src/config-ini.c
+++ b/src/config-ini.c
@@ -17,6 +17,9 @@
    Copyright (c) 2010  Jon Lund Steffensen <jonlst@gmail.com>
 */
 
+#ifdef HAVE_CONFIG_H
+# include "config.h"
+#endif
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/src/gamma-drm.c
+++ b/src/gamma-drm.c
@@ -18,6 +18,10 @@
    Copyright (c) 2017  Jon Lund Steffensen <jonlst@gmail.com>
 */
 
+#ifdef HAVE_CONFIG_H
+# include "config.h"
+#endif
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdint.h>

--- a/src/gamma-dummy.c
+++ b/src/gamma-dummy.c
@@ -17,6 +17,10 @@
    Copyright (c) 2013-2017  Jon Lund Steffensen <jonlst@gmail.com>
 */
 
+#ifdef HAVE_CONFIG_H
+# include "config.h"
+#endif
+
 #include <stdio.h>
 #include <stdlib.h>
 

--- a/src/gamma-randr.c
+++ b/src/gamma-randr.c
@@ -17,6 +17,10 @@
    Copyright (c) 2010-2017  Jon Lund Steffensen <jonlst@gmail.com>
 */
 
+#ifdef HAVE_CONFIG_H
+# include "config.h"
+#endif
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdint.h>

--- a/src/gamma-vidmode.c
+++ b/src/gamma-vidmode.c
@@ -17,6 +17,10 @@
    Copyright (c) 2010-2017  Jon Lund Steffensen <jonlst@gmail.com>
 */
 
+#ifdef HAVE_CONFIG_H
+# include "config.h"
+#endif
+
 #include <stdlib.h>
 #include <stdio.h>
 #include <stdint.h>

--- a/src/gamma-w32gdi.c
+++ b/src/gamma-w32gdi.c
@@ -17,6 +17,10 @@
    Copyright (c) 2010-2017  Jon Lund Steffensen <jonlst@gmail.com>
 */
 
+#ifdef HAVE_CONFIG_H
+# include "config.h"
+#endif
+
 #include <stdio.h>
 #include <stdlib.h>
 

--- a/src/location-geoclue2.c
+++ b/src/location-geoclue2.c
@@ -17,6 +17,10 @@
    Copyright (c) 2014-2017  Jon Lund Steffensen <jonlst@gmail.com>
 */
 
+#ifdef HAVE_CONFIG_H
+# include "config.h"
+#endif
+
 #include <stdio.h>
 #include <stdlib.h>
 

--- a/src/location-manual.c
+++ b/src/location-manual.c
@@ -17,6 +17,10 @@
    Copyright (c) 2010-2017  Jon Lund Steffensen <jonlst@gmail.com>
 */
 
+#ifdef HAVE_CONFIG_H
+# include "config.h"
+#endif
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <math.h>


### PR DESCRIPTION
`ENABLE_NLS` is always undefined in some files and some translatable messages in these files are always displayed in English. This commit fixes the issue.

Files:
* `config-ini.c`
* `gamma-drm.c`
* `gamma-dummy.c`
* `gamma-randr.c`
* `gamma-vidmode.c`
* `gamma-w32gdi.c`
* `location-geoclue2.c`
* `location-manual.c`

Examples:
* `redshift -m randr:help`
* `redshift -l manual:help`