### PR TITLE
prevent desktop file from being written in .config/autostart [Fixes #686]

### DIFF
--- a/src/redshift-gtk/utils.py
+++ b/src/redshift-gtk/utils.py
@@ -55,7 +55,9 @@ def open_autostart_file():
         dfile = DesktopEntry.DesktopEntry(desktop_file_path)
         for key, values in AUTOSTART_KEYS:
             dfile.set(key, values[False])
-        dfile.write(filename=autostart_file)
+        # do not write the file in local autostart as it override the one
+        # potentially found in /etc/xdg/autostart
+        #dfile.write(filename=autostart_file)
     else:
         dfile = DesktopEntry.DesktopEntry(autostart_file)
 


### PR DESCRIPTION
When the `redshift-gtk.desktop` file is present in `/etc/xdg/autostart` directory, at first session opening, it is creating the same file in `~/.config/autostart`.
On second startup, redshift does not start (seems to be linked to finding the 2 files).

This fix is preventing from creating the file in `~/.config/autostart`