### PR TITLE
src/redshift.c: Use localtime_s() on Windows

### DIFF
--- a/src/redshift.c
+++ b/src/redshift.c
@@ -28,6 +28,7 @@
 #include <math.h>
 #include <locale.h>
 #include <errno.h>
+#include <time.h>
 
 /* poll.h is not available on Windows but there is no Windows location provider
    using polling. On Windows, we just define some stubs to make things compile.
@@ -210,7 +211,11 @@ get_seconds_since_midnight(double timestamp)
 {
 	time_t t = (time_t)timestamp;
 	struct tm tm;
+#ifdef _WIN32
+	localtime_s(&tm, &t);
+#else
 	localtime_r(&t, &tm);
+#endif
 	return tm.tm_sec + tm.tm_min * 60 + tm.tm_hour * 3600;
 }
 


### PR DESCRIPTION
AppVeyor's GCC no longer supports `localtime_r()`:
```
make[4]: Entering directory '/c/projects/redshift/redshift-1.12/_build/sub/src'
  CC       colorramp.o
  CC       config-ini.o
  CC       gamma-dummy.o
  CC       hooks.o
  CC       location-manual.o
  CC       options.o
  CC       pipeutils.o
  CC       redshift.o
../../../src/redshift.c: In function 'get_seconds_since_midnight':
../../../src/redshift.c:213:2: warning: implicit declaration of function 'localtime_r'; did you mean 'localtime_s'? [-Wimplicit-function-declaration]
  213 |  localtime_r(&t, &tm);
      |  ^~~~~~~~~~~
      |  localtime_s
  CC       signals.o
  CC       solar.o
  CC       systemtime.o
  CC       gamma-w32gdi.o
  GEN      windows/appicon.o
  GEN      windows/versioninfo.o
  OBJCLD   redshift.exe
redshift.o: In function `get_seconds_since_midnight':
C:\projects\redshift\redshift-1.12\_build\sub\src/../../../src/redshift.c:213: undefined reference to `localtime_r'
collect2.exe: error: ld returned 1 exit status
make[4]: *** [Makefile:677: redshift.exe] Error 1
make[4]: Leaving directory '/c/projects/redshift/redshift-1.12/_build/sub/src'
make[3]: *** [Makefile:780: all-recursive] Error 1
make[3]: Leaving directory '/c/projects/redshift/redshift-1.12/_build/sub/src'
make[2]: *** [Makefile:775: all-recursive] Error 1
make[2]: Leaving directory '/c/projects/redshift/redshift-1.12/_build/sub'
make[1]: *** [Makefile:519: all] Error 2
make[1]: Leaving directory '/c/projects/redshift/redshift-1.12/_build/sub'
make: *** [Makefile:988: distcheck] Error 1
Command exited with code 2
```
We need to use `localtime_s()` on Windows.