### PR TITLE
Tweak systemd service files to avoid early startup failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,18 @@ Please go to [the issue tracker](https://github.com/jonls/redshift/issues) and
 check if your issue has already been reported. If not, please open a new issue
 describing you problem.
 
+
+**When running as a systemd service, redshift fails to connect to
+Xorg/Wayland**
+
+You need to export your environment variables when you window manager or
+compositor start up. Typically, you want to run this as part of its startup:
+
+    systemctl --user import-environment; systemctl --user start graphical-session.target
+
+See your compositor's (or window manager's) documentation for further details
+of setting up the systemd user session.
+
 Latest builds from master branch
 --------------------------------
 

--- a/data/systemd/redshift-gtk.service.in
+++ b/data/systemd/redshift-gtk.service.in
@@ -8,4 +8,4 @@ ExecStart=@bindir@/redshift-gtk
 Restart=always
 
 [Install]
-WantedBy=default.target
+WantedBy=graphical-session.target

--- a/data/systemd/redshift-gtk.service.in
+++ b/data/systemd/redshift-gtk.service.in
@@ -1,7 +1,7 @@
 [Unit]
 Description=Redshift display colour temperature adjustment (GUI)
 Documentation=http://jonls.dk/redshift/
-After=display-manager.service
+After=graphical-session.target
 
 [Service]
 ExecStart=@bindir@/redshift-gtk

--- a/data/systemd/redshift.service.in
+++ b/data/systemd/redshift.service.in
@@ -1,7 +1,7 @@
 [Unit]
 Description=Redshift display colour temperature adjustment
 Documentation=http://jonls.dk/redshift/
-After=display-manager.service
+After=graphical-session.target
 
 [Service]
 ExecStart=@bindir@/redshift

--- a/data/systemd/redshift.service.in
+++ b/data/systemd/redshift.service.in
@@ -8,4 +8,4 @@ ExecStart=@bindir@/redshift
 Restart=always
 
 [Install]
-WantedBy=default.target
+WantedBy=graphical-session.target


### PR DESCRIPTION
This PR addresses two somewhat similar issues in the systemd service files, that address failures due to redshift starting up too early.

See the commit messages on each commit for further in-depth explanation of both (since they're slightly separate issues, but amount to very similar problems).

Very strongly related to #742, but doesn't entirely fix it.