### PR TITLE
redshift-gtk: use Ayatana AppIndicator3 instead of App Indicator3

### DIFF
--- a/src/redshift-gtk/statusicon.py
+++ b/src/redshift-gtk/statusicon.py
@@ -33,8 +33,8 @@ gi.require_version('Gtk', '3.0')
 from gi.repository import Gtk, GLib
 
 try:
-    gi.require_version('AppIndicator3', '0.1')
-    from gi.repository import AppIndicator3 as appindicator
+    gi.require_version('AyatanaAppIndicator3', '0.1')
+    from gi.repository import AyatanaAppIndicator3 as appindicator
 except (ImportError, ValueError):
     appindicator = None
 


### PR DESCRIPTION
libappindicator was deprecated and it will be removed in the
future Debian release.

  https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=895037

There is a successor API compatible library - Ayatana Indicator.

  https://ayatanaindicators.github.io/code/