### PR TITLE
chore(location-geoclue2):The return type of this function g_variant_get_double，should be gdouble.

### DIFF
--- a/src/location-geoclue2.c
+++ b/src/location-geoclue2.c
@@ -50,8 +50,8 @@ typedef struct {
 	int pipe_fd_write;
 	int available;
 	int error;
-	float latitude;
-	float longitude;
+	gdouble latitude;
+	gdouble longitude;
 } location_geoclue2_state_t;
 
 


### PR DESCRIPTION
The return type of this function g_variant_get_double，should be gdouble.