### PR TITLE
redshift-gtk-desktop.in: Remove StartupNotify.

### DIFF
--- a/data/applications/redshift-gtk.desktop.in
+++ b/data/applications/redshift-gtk.desktop.in
@@ -8,4 +8,3 @@ Icon=redshift
 Terminal=false
 Type=Application
 Categories=Utility;
-StartupNotify=true


### PR DESCRIPTION
If redshift 'autostart' is enabled from the status icon, this will
produce the 'busy' mouse pointer when the desktop is initially
presented, giving the impression that the desktop itself hasn't
fully finished loading.

This also eliminates the startup notification  when starting this
from a launcher/start menu, but since the only visual change when
this happens (other than the actual program effect) is a status
icon, I don't think this is a concern.