### PR TITLE
Add fullscreen bypass support

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,9 +50,10 @@ Dependencies
 
 * autotools, gettext
 * intltool, libtool
+* libX11
 * libdrm (Optional, for DRM support)
 * libxcb, libxcb-randr (Optional, for RandR support)
-* libX11, libXxf86vm (Optional, for VidMode support)
+* libXxf86vm (Optional, for VidMode support)
 * Glib 2 (Optional, for GeoClue2 support)
 
 * python3, pygobject, pyxdg (Optional, for GUI support)

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -7,6 +7,7 @@ data/applications/redshift-gtk.desktop.in
 src/redshift.c
 src/options.c
 src/config-ini.c
+src/fullscreen.c
 
 src/gamma-drm.c
 src/gamma-randr.c

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -19,7 +19,8 @@ redshift_SOURCES = \
 	redshift.c redshift.h \
 	signals.c signals.h \
 	solar.c solar.h \
-	systemtime.c systemtime.h
+	systemtime.c systemtime.h \
+	fullscreen.c fullscreen.h
 
 EXTRA_redshift_SOURCES = \
 	gamma-drm.c gamma-drm.h \

--- a/src/fullscreen.c
+++ b/src/fullscreen.c
@@ -1,0 +1,94 @@
+/* fullscreen.h -- Fullscreen detector
+   This file is part of Redshift.
+
+   Redshift is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   Redshift is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with Redshift.  If not, see <http://www.gnu.org/licenses/>.
+
+   Copyright (c) 2021  Angelo Elias Dalzotto <angelodalzotto97@gmail.com>
+*/
+
+#ifdef HAVE_CONFIG_H
+# include "config.h"
+#endif
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <stdint.h>
+#include <string.h>
+
+#ifdef ENABLE_NLS
+# include <libintl.h>
+# define _(s) gettext(s)
+#else
+# define _(s) s
+#endif
+
+#ifndef _WIN32
+# include <X11/Xlib.h>
+#endif
+
+#include "fullscreen.h"
+#include "redshift.h"
+
+static Display *display;
+static int screen_width, screen_height;
+
+static int
+fullscreen_init()
+{
+#ifndef _WIN32
+	screen_height = -1;
+	screen_width = -1;
+	display = XOpenDisplay(NULL);
+	if (display == NULL) {
+		fprintf(stderr, _("X request failed: %s\n"), "XOpenDisplay");
+		return -1;
+	}
+
+	int screen = DefaultScreen(display);
+	screen_width = DisplayWidth(display, screen);
+	screen_height = DisplayHeight(display, screen);
+#endif
+
+	return 0;
+}
+
+static int
+fullscreen_check()
+{
+#ifndef _WIN32
+	Window window;
+	int revert_to = RevertToParent;
+	int result = XGetInputFocus(display, &window, &revert_to);
+
+	int win_x, win_y, win_w, win_h, win_b, win_d;
+	if(result) {
+		Window rootWindow;
+		result = XGetGeometry(display, window, &rootWindow, &win_x, &win_y, &win_w, &win_h, &win_b, &win_d);
+	}
+
+	if (result && win_w == screen_width && win_h == screen_height) {
+		return 1;
+	} else {
+#endif
+		return 0;
+#ifndef _WIN32
+	}
+#endif
+}
+
+const fullscreen_t fullscreen = {
+	"fullscreen",
+	(fullscreen_init_func *)fullscreen_init,
+	(fullscreen_check_func *)fullscreen_check,
+};

--- a/src/fullscreen.c
+++ b/src/fullscreen.c
@@ -40,8 +40,10 @@
 #include "fullscreen.h"
 #include "redshift.h"
 
+#ifndef _WIN32
 static Display *display;
 static int screen_width, screen_height;
+#endif
 
 static int
 fullscreen_init()

--- a/src/fullscreen.c
+++ b/src/fullscreen.c
@@ -42,24 +42,17 @@
 
 #ifndef _WIN32
 static Display *display;
-static int screen_width, screen_height;
 #endif
 
 static int
 fullscreen_init()
 {
 #ifndef _WIN32
-	screen_height = -1;
-	screen_width = -1;
 	display = XOpenDisplay(NULL);
 	if (display == NULL) {
 		fprintf(stderr, _("X request failed: %s\n"), "XOpenDisplay");
 		return -1;
 	}
-
-	int screen = DefaultScreen(display);
-	screen_width = DisplayWidth(display, screen);
-	screen_height = DisplayHeight(display, screen);
 #endif
 
 	return 0;
@@ -71,15 +64,19 @@ fullscreen_check()
 #ifndef _WIN32
 	Window window;
 	int revert_to = RevertToParent;
-	int result = XGetInputFocus(display, &window, &revert_to);
+	int result = XGetInputFocus(display, &window, &revert_to);	
 
 	int win_x, win_y, win_w, win_h, win_b, win_d;
-	if(result) {
+	int scr_x, scr_y, scr_w, scr_h, scr_b, scr_d;
+	if (result) {
 		Window rootWindow;
 		result = XGetGeometry(display, window, &rootWindow, &win_x, &win_y, &win_w, &win_h, &win_b, &win_d);
+		if (rootWindow) {
+			result = XGetGeometry(display, rootWindow, &rootWindow, &scr_x, &scr_y, &scr_w, &scr_h, &scr_b, &scr_d);
+		}
 	}
 
-	if (result && win_w == screen_width && win_h == screen_height) {
+	if (result && win_w == scr_w && win_h == scr_h) {
 		return 1;
 	} else {
 #endif

--- a/src/fullscreen.h
+++ b/src/fullscreen.h
@@ -1,0 +1,28 @@
+/* fullscreen.h -- Fullscreen detector header
+   This file is part of Redshift.
+
+   Redshift is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   Redshift is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with Redshift.  If not, see <http://www.gnu.org/licenses/>.
+
+   Copyright (c) 2021  Angelo Elias Dalzotto <angelodalzotto97@gmail.com>
+*/
+
+#ifndef REDSHIFT_FULLSCREEN_H
+#define REDSHIFT_FULLSCREEN_H
+
+#include "redshift.h"
+
+extern const fullscreen_t fullscreen;
+
+#endif /* ! REDSHIFT_FULLSCREEN_H */
+

--- a/src/options.c
+++ b/src/options.c
@@ -178,6 +178,7 @@ print_help(const char *program_name)
 	   no-wrap */
 	fputs(_("  -b DAY:NIGHT\tScreen brightness to apply (between 0.1 and 1.0)\n"
 		"  -c FILE\tLoad settings from specified configuration file\n"
+		"  -f BOOL\tEnable or disable fullscreen windows bypass\n"
 		"  -g R:G:B\tAdditional gamma correction to apply\n"
 		"  -l LAT:LON\tYour current location\n"
 		"  -l PROVIDER\tSelect provider for automatic"
@@ -323,6 +324,7 @@ options_init(options_t *options)
 	options->preserve_gamma = 1;
 	options->mode = PROGRAM_MODE_CONTINUAL;
 	options->verbose = 0;
+	options->fullscreen_check = 1;
 }
 
 /* Parse a single option from the command-line. */
@@ -344,6 +346,9 @@ parse_command_line_option(
 	case 'c':
 		free(options->config_filepath);
 		options->config_filepath = strdup(value);
+		break;
+	case 'f':
+		options->fullscreen_check = atoi(value);
 		break;
 	case 'g':
 		r = parse_gamma_string(value, options->scheme.day.gamma);
@@ -495,7 +500,7 @@ options_parse_args(
 {
 	const char* program_name = argv[0];
 	int opt;
-	while ((opt = getopt(argc, argv, "b:c:g:hl:m:oO:pPrt:vVx")) != -1) {
+	while ((opt = getopt(argc, argv, "b:c:f:g:hl:m:oO:pPrt:vVx")) != -1) {
 		char option = opt;
 		int r = parse_command_line_option(
 			option, optarg, options, program_name, gamma_methods,

--- a/src/options.h
+++ b/src/options.h
@@ -29,6 +29,7 @@ typedef struct {
 	transition_scheme_t scheme;
 	program_mode_t mode;
 	int verbose;
+	int fullscreen_check;
 
 	/* Temperature to set in manual mode. */
 	int temp_set;

--- a/src/redshift.c
+++ b/src/redshift.c
@@ -66,6 +66,7 @@ int poll(struct pollfd *fds, int nfds, int timeout) { abort(); return -1; }
 #include "hooks.h"
 #include "signals.h"
 #include "options.h"
+#include "fullscreen.h"
 
 /* pause() is not defined on windows platform but is not needed either.
    Use a noop macro instead. */
@@ -608,7 +609,7 @@ run_continual_mode(const location_provider_t *provider,
 		   const transition_scheme_t *scheme,
 		   const gamma_method_t *method,
 		   gamma_state_t *method_state,
-		   int use_fade, int preserve_gamma, int verbose)
+		   int use_fade, int preserve_gamma, int fullscreen_check, int verbose)
 {
 	int r;
 
@@ -662,16 +663,29 @@ run_continual_mode(const location_provider_t *provider,
 		printf(_("Brightness: %.2f\n"), interp.brightness);
 	}
 
+	if (fullscreen_check) {
+		fullscreen.init();
+	}
+
 	/* Continuously adjust color temperature */
 	int done = 0;
 	int prev_disabled = 1;
 	int disabled = 0;
 	int location_available = 1;
+	int prev_fullscreen = 0;
+	int is_fullscreen = 0;
+	int fs_disabled = 0;
 	while (1) {
 		/* Check to see if disable signal was caught */
 		if (disable && !done) {
 			disabled = !disabled;
 			disable = 0;
+		}
+
+		/* Check to see if fs_disable signal was caught */
+		if (fs_disable && !done){
+			fs_disabled = !fs_disabled;
+			fs_disable = 0;
 		}
 
 		/* Check to see if exit signal was caught */
@@ -686,13 +700,20 @@ run_continual_mode(const location_provider_t *provider,
 			exiting = 0;
 		}
 
+		if (fullscreen_check && fullscreen.check() && !done && !fs_disabled) {
+			is_fullscreen = 1;
+		} else {
+			is_fullscreen = 0;
+		}
+
 		/* Print status change */
-		if (verbose && disabled != prev_disabled) {
-			printf(_("Status: %s\n"), disabled ?
+		if (verbose && ((disabled || is_fullscreen) != (prev_disabled || prev_fullscreen))) {
+			printf(_("Status: %s\n"), (disabled || is_fullscreen) ?
 			       _("Disabled") : _("Enabled"));
 		}
 
 		prev_disabled = disabled;
+		prev_fullscreen = is_fullscreen;
 
 		/* Read timestamp */
 		double now;
@@ -727,7 +748,7 @@ run_continual_mode(const location_provider_t *provider,
 		interpolate_transition_scheme(
 			scheme, transition_prog, &target_interp);
 
-		if (disabled) {
+		if (disabled || is_fullscreen) {
 			period = PERIOD_NONE;
 			color_setting_reset(&target_interp);
 		}
@@ -1308,6 +1329,7 @@ main(int argc, char *argv[])
 			options.provider, location_state, scheme,
 			options.method, method_state,
 			options.use_fade, options.preserve_gamma,
+			options.fullscreen_check,
 			options.verbose);
 		if (r < 0) exit(EXIT_FAILURE);
 	}

--- a/src/redshift.c
+++ b/src/redshift.c
@@ -672,9 +672,9 @@ run_continual_mode(const location_provider_t *provider,
 	int prev_disabled = 1;
 	int disabled = 0;
 	int location_available = 1;
-	int prev_fullscreen = 0;
+	int prev_fs_bypass_disabled = 1;
+	int fs_bypass_disabled = 0;
 	int is_fullscreen = 0;
-	int fs_disabled = 0;
 	while (1) {
 		/* Check to see if disable signal was caught */
 		if (disable && !done) {
@@ -683,9 +683,9 @@ run_continual_mode(const location_provider_t *provider,
 		}
 
 		/* Check to see if fs_disable signal was caught */
-		if (fs_disable && !done){
-			fs_disabled = !fs_disabled;
-			fs_disable = 0;
+		if (fs_bypass_disable && !done){
+			fs_bypass_disabled = !fs_bypass_disabled;
+			fs_bypass_disable = 0;
 		}
 
 		/* Check to see if exit signal was caught */
@@ -700,20 +700,26 @@ run_continual_mode(const location_provider_t *provider,
 			exiting = 0;
 		}
 
-		if (fullscreen_check && fullscreen.check() && !done && !fs_disabled) {
+		if (fullscreen.check() && !done && !fs_bypass_disabled) {
 			is_fullscreen = 1;
 		} else {
 			is_fullscreen = 0;
 		}
 
 		/* Print status change */
-		if (verbose && ((disabled || is_fullscreen) != (prev_disabled || prev_fullscreen))) {
-			printf(_("Status: %s\n"), (disabled || is_fullscreen) ?
+		if (verbose && disabled != prev_disabled) {
+			printf(_("Status: %s\n"), disabled ?
+			       _("Disabled") : _("Enabled"));
+		}
+
+		/* Print fullscreen bypass enable/disable change */
+		if (verbose && fs_bypass_disabled != prev_fs_bypass_disabled) {
+			printf(_("Fullscreen bypass: %s\n"), fs_bypass_disabled ?
 			       _("Disabled") : _("Enabled"));
 		}
 
 		prev_disabled = disabled;
-		prev_fullscreen = is_fullscreen;
+		prev_fs_bypass_disabled = fs_bypass_disabled;
 
 		/* Read timestamp */
 		double now;

--- a/src/redshift.h
+++ b/src/redshift.h
@@ -150,4 +150,18 @@ typedef struct {
 } location_provider_t;
 
 
+/* Fullscreen detector */
+typedef int fullscreen_init_func();
+typedef int fullscreen_check_func();
+
+typedef struct {
+	char *name;
+
+	/* Initialize display. */
+	fullscreen_init_func *init;
+
+	/* Check if active window is fullscreen. */
+	fullscreen_check_func *check;
+} fullscreen_t;
+
 #endif /* ! REDSHIFT_REDSHIFT_H */

--- a/src/signals.c
+++ b/src/signals.c
@@ -34,7 +34,7 @@
 
 volatile sig_atomic_t exiting = 0;
 volatile sig_atomic_t disable = 0;
-volatile sig_atomic_t fs_disable = 0;
+volatile sig_atomic_t fs_bypass_disable = 0;
 
 
 /* Signal handler for exit signals */
@@ -53,16 +53,16 @@ sigdisable(int signo)
 
 /* Signal handler for disabling the fullscreen detector signal */
 static void
-sigfsdisable(int signo)
+sigfsbypassdisable(int signo)
 {
-	fs_disable = 1;
+	fs_bypass_disable = 1;
 }
 
 #else /* ! HAVE_SIGNAL_H || __WIN32__ */
 
 int disable = 0;
 int exiting = 0;
-int fs_disable = 0;
+int fs_bypass_disable = 0;
 
 #endif /* ! HAVE_SIGNAL_H || __WIN32__ */
 
@@ -105,7 +105,7 @@ signals_install_handlers(void)
 	}
 
 	/* Install signal handler for USR2 signal */
-	sigact.sa_handler = sigfsdisable;
+	sigact.sa_handler = sigfsbypassdisable;
 	sigact.sa_mask = sigset;
 	sigact.sa_flags = 0;
 

--- a/src/signals.h
+++ b/src/signals.h
@@ -25,10 +25,12 @@
 
 extern volatile sig_atomic_t exiting;
 extern volatile sig_atomic_t disable;
+extern volatile sig_atomic_t fs_disable;
 
 #else /* ! HAVE_SIGNAL_H || __WIN32__ */
 extern int exiting;
 extern int disable;
+extern int fs_disable;
 #endif /* ! HAVE_SIGNAL_H || __WIN32__ */
 
 

--- a/src/signals.h
+++ b/src/signals.h
@@ -25,12 +25,12 @@
 
 extern volatile sig_atomic_t exiting;
 extern volatile sig_atomic_t disable;
-extern volatile sig_atomic_t fs_disable;
+extern volatile sig_atomic_t fs_bypass_disable;
 
 #else /* ! HAVE_SIGNAL_H || __WIN32__ */
 extern int exiting;
 extern int disable;
-extern int fs_disable;
+extern int fs_bypass_disable;
 #endif /* ! HAVE_SIGNAL_H || __WIN32__ */
 
 


### PR DESCRIPTION
This pull request adds support for automatically disabling redshift when a fullscreen application is detected, solving issue #548.
There is a possibility to disable this function from command line with the option "-f 0".

Differing from #407, this implements the function in the redshift daemon.
It does not use the EWMH because it is not reliable enough (confirmed poor compatibility with i3).
No implementation has been made for Windows yet, but the code should still compile.

___

EDIT:
Also, there is a SIGUSR2 and a checkbox in redshift-gtk to disable this function at any time.

___

EDIT:
Multi-monitor support is a bit tricky and must be decided how it should work before it is developed.
I think it must check if the focused window is fullscreen in its display and disable redshift for all displays, or make a per-display control, but I don't know if this is possible.