### PR TITLE
Add signal exit handler for SIGQUIT

### DIFF
--- a/src/signals.c
+++ b/src/signals.c
@@ -84,6 +84,12 @@ signals_install_handlers(void)
 		return -1;
 	}
 
+	r = sigaction(SIGQUIT, &sigact, NULL);
+	if (r < 0) {
+		perror("sigaction");
+		return -1;
+	}
+
 	/* Install signal handler for USR1 signal */
 	sigact.sa_handler = sigdisable;
 	sigact.sa_mask = sigset;


### PR DESCRIPTION
When I call redshift on the command line:
`$ redshift`

My config is being applied and redshift is waiting.
If I press Ctrl-C, then redshift exits normally and the configuration is reset
If I press Ctrl-\ then redshift just exits and doesn't reset its config, my screen stays red

This PR solves this problem by exposing a handler for the SIGQUIT signal.
It sometimes comes in handy when, for example, a person has bind on Ctrl-C, which copies the text.