### PR TITLE
Update Linux coding style link in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,7 +65,7 @@ Coding style for C code
 -----------------------
 
 Redshift follows roughly the Linux coding style
-<http://www.kernel.org/doc/Documentation/CodingStyle>. Some specific rules to
+<https://www.kernel.org/doc/html/v4.10/process/coding-style.html>. Some specific rules to
 note are:
 
 * Lines should not be longer than 80 characters in new code. If lines are


### PR DESCRIPTION
The Linux coding style documentation has since been moved and the old link now informs the user to go to this new link instead