### PR TITLE
Add feature to adjust fade duration (without Elektra)

### DIFF
--- a/src/options.c
+++ b/src/options.c
@@ -537,6 +537,16 @@ parse_config_file_option(
 		if (options->use_fade < 0) {
 			options->use_fade = !!atoi(value);
 		}
+	} else if (strcasecmp(key, "fade-duration") == 0) {
+	    if (options->fade_duration < 0) {
+            errno = 0;
+            long fade_duration = strtol(value, NULL, 10);
+            if (errno != 0 || fade_duration <= 0) {
+                fputs(_("Malformed fade duration setting.\n"), stderr);
+                return -1;
+            }
+            options->fade_duration = fade_duration;
+	    }
 	} else if (strcasecmp(key, "brightness") == 0) {
 		if (isnan(options->scheme.day.brightness)) {
 			options->scheme.day.brightness = atof(value);

--- a/src/options.c
+++ b/src/options.c
@@ -457,6 +457,16 @@ parse_command_line_option(
 	case 'r':
 		options->use_fade = 0;
 		break;
+    case 'f':
+        errno = 0;
+        long fade_duration = strtol(value, NULL, 10);
+        if (errno != 0 || fade_duration <= 0) {
+            fputs(_("Malformed fade duration argument.\n"), stderr);
+            fputs(_("Try `-h' for more information.\n"), stderr);
+            return -1;
+        }
+        options->fade_duration = fade_duration;
+        break;
 	case 't':
 		s = strchr(value, ':');
 		if (s == NULL) {
@@ -496,7 +506,7 @@ options_parse_args(
 {
 	const char* program_name = argv[0];
 	int opt;
-	while ((opt = getopt(argc, argv, "b:c:g:hl:m:oO:pPrt:vVx")) != -1) {
+	while ((opt = getopt(argc, argv, "b:c:g:hl:m:oO:pPrf:t:vVx")) != -1) {
 		char option = opt;
 		int r = parse_command_line_option(
 			option, optarg, options, program_name, gamma_methods,

--- a/src/options.c
+++ b/src/options.c
@@ -460,7 +460,7 @@ parse_command_line_option(
 		break;
     case 'f':
         errno = 0;
-        unsigned long fade_duration = strtoul(value, NULL, 10);
+        long fade_duration = strtol(value, NULL, 10);
         if (errno != 0 || fade_duration <= 0) {
             fputs(_("Malformed fade duration argument.\n"), stderr);
             fputs(_("Try `-h' for more information.\n"), stderr);
@@ -541,7 +541,7 @@ parse_config_file_option(
 	} else if (strcasecmp(key, "fade-duration") == 0) {
 	    if (options->fade_duration < 0) {
             errno = 0;
-            unsigned long fade_duration = strtoul(value, NULL, 10);
+            long fade_duration = strtol(value, NULL, 10);
             if (errno != 0 || fade_duration <= 0) {
                 fputs(_("Malformed fade duration setting.\n"), stderr);
                 return -1;

--- a/src/options.c
+++ b/src/options.c
@@ -320,6 +320,7 @@ options_init(options_t *options)
 	options->provider_args = NULL;
 
 	options->use_fade = -1;
+    options->fade_duration = -1;
 	options->preserve_gamma = 1;
 	options->mode = PROGRAM_MODE_CONTINUAL;
 	options->verbose = 0;
@@ -676,4 +677,6 @@ options_set_defaults(options_t *options)
 	}
 
 	if (options->use_fade < 0) options->use_fade = 1;
+	
+	if (options->fade_duration < 0) options->fade_duration = 4000; // Set default fade duration to 4 seconds.
 }

--- a/src/options.c
+++ b/src/options.c
@@ -699,5 +699,5 @@ options_set_defaults(options_t *options)
 
 	if (options->use_fade < 0) options->use_fade = 1;
 	
-	if (options->fade_duration < 0) options->fade_duration = 4000; // Set default fade duration to 4 seconds.
+	if (options->fade_duration < 0) options->fade_duration = 4; // Set default fade duration to 4 seconds.
 }

--- a/src/options.c
+++ b/src/options.c
@@ -193,6 +193,7 @@ print_help(const char *program_name)
 		" color effect\n"
 		"  -x\t\tReset mode (remove adjustment from screen)\n"
 		"  -r\t\tDisable fading between color temperatures\n"
+        "  -f\t\tSet fade duration (for fading between color temperatures) in full seconds\n"
 		"  -t DAY:NIGHT\tColor temperature to set at daytime/night\n"),
 	      stdout);
 	fputs("\n", stdout);

--- a/src/options.c
+++ b/src/options.c
@@ -460,7 +460,7 @@ parse_command_line_option(
 		break;
     case 'f':
         errno = 0;
-        long fade_duration = strtol(value, NULL, 10);
+        unsigned long fade_duration = strtoul(value, NULL, 10);
         if (errno != 0 || fade_duration <= 0) {
             fputs(_("Malformed fade duration argument.\n"), stderr);
             fputs(_("Try `-h' for more information.\n"), stderr);
@@ -541,7 +541,7 @@ parse_config_file_option(
 	} else if (strcasecmp(key, "fade-duration") == 0) {
 	    if (options->fade_duration < 0) {
             errno = 0;
-            long fade_duration = strtol(value, NULL, 10);
+            unsigned long fade_duration = strtoul(value, NULL, 10);
             if (errno != 0 || fade_duration <= 0) {
                 fputs(_("Malformed fade duration setting.\n"), stderr);
                 return -1;

--- a/src/options.c
+++ b/src/options.c
@@ -105,7 +105,7 @@ parse_transition_time(const char *str, const char **end)
 	errno = 0;
 	long hours = strtol(str, (char **)&min, 10);
 	if (errno != 0 || min == str || min[0] != ':' ||
-	    hours < 0 || hours >= 24) {
+		hours < 0 || hours >= 24) {
 		return -1;
 	}
 
@@ -193,9 +193,9 @@ print_help(const char *program_name)
 		" color effect\n"
 		"  -x\t\tReset mode (remove adjustment from screen)\n"
 		"  -r\t\tDisable fading between color temperatures\n"
-        "  -f\t\tSet fade duration (for fading between color temperatures) in full seconds\n"
+		"  -f\t\tSet fade duration (for fading between color temperatures) in full seconds\n"
 		"  -t DAY:NIGHT\tColor temperature to set at daytime/night\n"),
-	      stdout);
+		  stdout);
 	fputs("\n", stdout);
 
 	/* TRANSLATORS: help output 5 */
@@ -211,7 +211,7 @@ print_help(const char *program_name)
 	printf(_("Default values:\n\n"
 		 "  Daytime temperature: %uK\n"
 		 "  Night temperature: %uK\n"),
-	       DEFAULT_DAY_TEMP, DEFAULT_NIGHT_TEMP);
+		   DEFAULT_DAY_TEMP, DEFAULT_NIGHT_TEMP);
 
 	fputs("\n", stdout);
 
@@ -359,8 +359,8 @@ parse_command_line_option(
 		   To set these to distinct values use the config
 		   file. */
 		memcpy(options->scheme.night.gamma,
-		       options->scheme.day.gamma,
-		       sizeof(options->scheme.night.gamma));
+			   options->scheme.day.gamma,
+			   sizeof(options->scheme.night.gamma));
 		break;
 	case 'h':
 		print_help(program_name);
@@ -406,7 +406,7 @@ parse_command_line_option(
 
 		/* Print provider help if arg is `help'. */
 		if (options->provider_args != NULL &&
-		    strcasecmp(options->provider_args, "help") == 0) {
+			strcasecmp(options->provider_args, "help") == 0) {
 			options->provider->print_help(stdout);
 			exit(EXIT_SUCCESS);
 		}
@@ -437,7 +437,7 @@ parse_command_line_option(
 
 		/* Print method help if arg is `help'. */
 		if (options->method_args != NULL &&
-		    strcasecmp(options->method_args, "help") == 0) {
+			strcasecmp(options->method_args, "help") == 0) {
 			options->method->print_help(stdout);
 			exit(EXIT_SUCCESS);
 		}
@@ -458,16 +458,16 @@ parse_command_line_option(
 	case 'r':
 		options->use_fade = 0;
 		break;
-    case 'f':
-        errno = 0;
-        long fade_duration = strtol(value, NULL, 10);
-        if (errno != 0 || fade_duration <= 0) {
-            fputs(_("Malformed fade duration argument.\n"), stderr);
-            fputs(_("Try `-h' for more information.\n"), stderr);
-            return -1;
-        }
-        options->fade_duration = fade_duration;
-        break;
+	case 'f':
+		errno = 0;
+		long fade_duration = strtol(value, NULL, 10);
+		if (errno != 0 || fade_duration <= 0) {
+			fputs(_("Malformed fade duration argument.\n"), stderr);
+			fputs(_("Try `-h' for more information.\n"), stderr);
+			return -1;
+		}
+		options->fade_duration = fade_duration;
+		break;
 	case 't':
 		s = strchr(value, ':');
 		if (s == NULL) {
@@ -539,15 +539,15 @@ parse_config_file_option(
 			options->use_fade = !!atoi(value);
 		}
 	} else if (strcasecmp(key, "fade-duration") == 0) {
-	    if (options->fade_duration < 0) {
-            errno = 0;
-            long fade_duration = strtol(value, NULL, 10);
-            if (errno != 0 || fade_duration <= 0) {
-                fputs(_("Malformed fade duration setting.\n"), stderr);
-                return -1;
-            }
-            options->fade_duration = fade_duration;
-	    }
+		if (options->fade_duration < 0) {
+			errno = 0;
+			long fade_duration = strtol(value, NULL, 10);
+			if (errno != 0 || fade_duration <= 0) {
+				fputs(_("Malformed fade duration setting.\n"), stderr);
+				return -1;
+			}
+			options->fade_duration = fade_duration;
+		}
 	} else if (strcasecmp(key, "brightness") == 0) {
 		if (isnan(options->scheme.day.brightness)) {
 			options->scheme.day.brightness = atof(value);
@@ -576,8 +576,8 @@ parse_config_file_option(
 				return -1;
 			}
 			memcpy(options->scheme.night.gamma,
-			       options->scheme.day.gamma,
-			       sizeof(options->scheme.night.gamma));
+				   options->scheme.day.gamma,
+				   sizeof(options->scheme.night.gamma));
 		}
 	} else if (strcasecmp(key, "gamma-day") == 0) {
 		if (isnan(options->scheme.day.gamma[0])) {

--- a/src/options.c
+++ b/src/options.c
@@ -321,7 +321,7 @@ options_init(options_t *options)
 	options->provider_args = NULL;
 
 	options->use_fade = -1;
-    options->fade_duration = -1;
+	options->fade_duration = -1;
 	options->preserve_gamma = 1;
 	options->mode = PROGRAM_MODE_CONTINUAL;
 	options->verbose = 0;

--- a/src/options.h
+++ b/src/options.h
@@ -34,6 +34,8 @@ typedef struct {
 	int temp_set;
 	/* Whether to fade between large skips in color temperature. */
 	int use_fade;
+	/* The length of the fade duration in seconds */
+	long fade_duration;
 	/* Whether to preserve gamma ramps if supported by gamma method. */
 	int preserve_gamma;
 

--- a/src/options.h
+++ b/src/options.h
@@ -35,7 +35,7 @@ typedef struct {
 	/* Whether to fade between large skips in color temperature. */
 	int use_fade;
 	/* The length of the fade duration in seconds */
-	long fade_duration;
+	unsigned long fade_duration;
 	/* Whether to preserve gamma ramps if supported by gamma method. */
 	int preserve_gamma;
 

--- a/src/options.h
+++ b/src/options.h
@@ -35,7 +35,7 @@ typedef struct {
 	/* Whether to fade between large skips in color temperature. */
 	int use_fade;
 	/* The length of the fade duration in seconds */
-	unsigned long fade_duration;
+	long fade_duration;
 	/* Whether to preserve gamma ramps if supported by gamma method. */
 	int preserve_gamma;
 

--- a/src/redshift.c
+++ b/src/redshift.c
@@ -608,7 +608,7 @@ run_continual_mode(const location_provider_t *provider,
 		   const transition_scheme_t *scheme,
 		   const gamma_method_t *method,
 		   gamma_state_t *method_state,
-		   int use_fade, long fade_duration,
+		   int use_fade, unsigned long fade_duration,
 		   int preserve_gamma, int verbose)
 {
 	int r;

--- a/src/redshift.c
+++ b/src/redshift.c
@@ -763,7 +763,7 @@ run_continual_mode(const location_provider_t *provider,
 				     &target_interp,
 				     &prev_target_interp))) {
 			    // Scale fade_length according to desired fade_duration.
-				fade_length = (FADE_LENGTH * fade_duration) / (FADE_LENGTH * SLEEP_DURATION_SHORT);
+				fade_length = (FADE_LENGTH * (fade_duration * 1000)) / (FADE_LENGTH * SLEEP_DURATION_SHORT);
                 fade_time = 0;
 				fade_start_interp = interp;
 			}

--- a/src/redshift.c
+++ b/src/redshift.c
@@ -608,7 +608,8 @@ run_continual_mode(const location_provider_t *provider,
 		   const transition_scheme_t *scheme,
 		   const gamma_method_t *method,
 		   gamma_state_t *method_state,
-		   int use_fade, int preserve_gamma, int verbose)
+		   int use_fade, long fade_duration,
+		   int preserve_gamma, int verbose)
 {
 	int r;
 
@@ -761,8 +762,9 @@ run_continual_mode(const location_provider_t *provider,
 			     color_setting_diff_is_major(
 				     &target_interp,
 				     &prev_target_interp))) {
-				fade_length = FADE_LENGTH;
-				fade_time = 0;
+			    // Scale fade_length according to desired fade_duration.
+				fade_length = (FADE_LENGTH / ((FADE_LENGTH * SLEEP_DURATION_SHORT) / fade_duration));
+                fade_time = 0;
 				fade_start_interp = interp;
 			}
 		}
@@ -1307,7 +1309,8 @@ main(int argc, char *argv[])
 		r = run_continual_mode(
 			options.provider, location_state, scheme,
 			options.method, method_state,
-			options.use_fade, options.preserve_gamma,
+			options.use_fade, options.fade_duration,
+			options.preserve_gamma,
 			options.verbose);
 		if (r < 0) exit(EXIT_FAILURE);
 	}

--- a/src/redshift.c
+++ b/src/redshift.c
@@ -608,7 +608,7 @@ run_continual_mode(const location_provider_t *provider,
 		   const transition_scheme_t *scheme,
 		   const gamma_method_t *method,
 		   gamma_state_t *method_state,
-		   int use_fade, unsigned long fade_duration,
+		   int use_fade, long fade_duration,
 		   int preserve_gamma, int verbose)
 {
 	int r;

--- a/src/redshift.c
+++ b/src/redshift.c
@@ -763,7 +763,7 @@ run_continual_mode(const location_provider_t *provider,
 				     &target_interp,
 				     &prev_target_interp))) {
 			    // Scale fade_length according to desired fade_duration.
-				fade_length = (FADE_LENGTH / ((FADE_LENGTH * SLEEP_DURATION_SHORT) / fade_duration));
+				fade_length = (FADE_LENGTH * fade_duration) / (FADE_LENGTH * SLEEP_DURATION_SHORT);
                 fade_time = 0;
 				fade_start_interp = interp;
 			}


### PR DESCRIPTION
@markus2330: This PR implements a new configuration value "fade duration" in redshift without Elektra.

It will be used to compare the implementation of new configuration values without vs. with Elektra.