### PR TITLE
Increase restart delay for systemd service

### DIFF
--- a/data/systemd/redshift-gtk.service.in
+++ b/data/systemd/redshift-gtk.service.in
@@ -6,6 +6,7 @@ After=graphical-session.target
 [Service]
 ExecStart=@bindir@/redshift-gtk
 Restart=always
+RestartSec=30
 
 [Install]
 WantedBy=graphical-session.target

--- a/data/systemd/redshift.service.in
+++ b/data/systemd/redshift.service.in
@@ -6,6 +6,7 @@ After=graphical-session.target
 [Service]
 ExecStart=@bindir@/redshift
 Restart=always
+RestartSec=30
 
 [Install]
 WantedBy=graphical-session.target


### PR DESCRIPTION
Redshift just crashed for me, presumably because the default `RestartSec` (100ms) is too short:
```sh
Oct 06 11:47:03 pavilion-arch systemd[473]: redshift.service: Scheduled restart job, restart counter is at 5.
Oct 06 11:47:03 pavilion-arch systemd[473]: Stopped Redshift display colour temperature adjustment.
Oct 06 11:47:03 pavilion-arch systemd[473]: redshift.service: Start request repeated too quickly.
Oct 06 11:47:03 pavilion-arch systemd[473]: redshift.service: Failed with result 'exit-code'.
Oct 06 11:47:03 pavilion-arch systemd[473]: Failed to start Redshift display colour temperature adjustment.
```