### PR TITLE
Fix segfault for LDAP-authenticated users

### DIFF
--- a/src/config-ini.c
+++ b/src/config-ini.c
@@ -101,15 +101,17 @@ open_config_file(const char *filepath)
 
 		if (f == NULL) {
 			struct passwd *pwd = getpwuid(getuid());
-			char *home = pwd->pw_dir;
-			snprintf(cp, sizeof(cp),
-				 "%s/.config/redshift/redshift.conf", home);
-			f = fopen(cp, "r");
-			if (f == NULL) {
-				/* Fall back to formerly used path. */
+			if (pwd != NULL) {
+				char *home = pwd->pw_dir;
 				snprintf(cp, sizeof(cp),
-					 "%s/.config/redshift.conf", home);
+					 "%s/.config/redshift/redshift.conf", home);
 				f = fopen(cp, "r");
+				if (f == NULL) {
+					/* Fall back to formerly used path. */
+					snprintf(cp, sizeof(cp),
+						 "%s/.config/redshift.conf", home);
+					f = fopen(cp, "r");
+				}
 			}
 		}
 


### PR DESCRIPTION
If a user is logged in via LDAP, some implementations of getpwuid() seem
to return NULL. Dereferencing this pointer will cause a segfault. This
change avoids dereferencing the potential NULL pointer.