### PR TITLE
Fix apparmor config.

### DIFF
--- a/data/apparmor/usr.bin.redshift.in
+++ b/data/apparmor/usr.bin.redshift.in
@@ -36,6 +36,11 @@
   audit dbus bus=system,
 
   owner @{HOME}/.config/redshift/redshift.conf r,
+  # Legacy config path
+  owner @{HOME}/.config/redshift.conf r,
+
+  # Required by getpwuid() call in config-ini.c.
+  /etc/passwd* r,
 
   # Site-specific additions and overrides. See local/README for details.
   #include <local/usr.bin.redshift>


### PR DESCRIPTION
Related bugs:
 * https://bugzilla.suse.com/show_bug.cgi?id=1111906
 * https://bugs.debian.org/988068
 * https://github.com/jonls/redshift/issues/672
 * https://github.com/jonls/redshift/pull/860

src/config-ini.c still looks for $HOME/.config/redshift.conf which
fails to open because the apparmor profile doesn’t allow it.

src/config-ini.c also does this:
```
   struct passwd *pwd = getpwuid(getuid());
   char *home = pwd->pw_dir;
```

Since getpwuid doesn’t have access to /etc/passwd* it returns NULL,
causing a segmentation fault in the line thereafter.
This code is not triggered if a config is specified (e.g.
-c redshift.conf) or $HOME/.config/redshift.conf exists.