### PR TITLE
Don't use legacy location for metainfo file

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -95,7 +95,7 @@ $(systemduserunit_DATA): $(SYSTEMD_USER_UNIT_IN_FILES) Makefile
 
 # Appdata file
 if ENABLE_GUI
-appdatadir = @datadir@/appdata
+appdatadir = @datadir@/metainfo
 appdata_DATA = $(APPDATA_IN_FILES:.xml.in=.xml)
 
 # We would preferable use @INTLTOOL_XML_RULE@ here but


### PR DESCRIPTION
See https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html#spec-component-location