### PR TITLE
Fix config file path for Linux in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ automatic location provider. An example configuration can be found in
 The configuration file should be saved in the following location depending on
 the platform:
 
-- Linux/macOS: `~/.config/redshift/redshift.conf` (if the environment variable `XDG_CONFIG_HOME` is undefined) or `${XDG_CONFIG_HOME}/redshift/redshift.conf` (if `XDG_CONFIG_HOME` is defined).
+- Linux/macOS: `~/.config/redshift.conf`.
 - Windows: Put `redshift.conf` in `%USERPROFILE%\AppData\Local\`
     (aka `%localappdata%`).
 


### PR DESCRIPTION
The config file path (`~/.config/redshift/redshift.conf`) in the currently provied README.md seems to be wrong (tested on Debian 12).

The correct file path is `~/.config/redshift.conf`.